### PR TITLE
Se 78 made memberships generic

### DIFF
--- a/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/net/corda/businessnetworks/ledgersync/EvaluateLedgerConsistencyFlow.kt
+++ b/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/net/corda/businessnetworks/ledgersync/EvaluateLedgerConsistencyFlow.kt
@@ -42,7 +42,7 @@ class RespondEvaluateLedgersConsistencyFlow(
      *          private val otherSideSession: FlowSession
      *      ) : BusinessNetworkAwareInitiatedFlow<Unit>(otherSideSession)
      *
-     * Subsequently `onOtherPartyMembershipVerified` can be used.
+     * Subsequently `onCounterpartyMembershipVerified` can be used.
      */
 
     @Suspendable

--- a/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/net/corda/businessnetworks/ledgersync/RequestLedgersSyncFlow.kt
+++ b/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/net/corda/businessnetworks/ledgersync/RequestLedgersSyncFlow.kt
@@ -44,7 +44,7 @@ class RespondLedgerSyncFlow(
      *          private val otherSideSession: FlowSession
      *      ) : BusinessNetworkAwareInitiatedFlow<Unit>(otherSideSession)
      *
-     * Subsequently `onOtherPartyMembershipVerified` can be used.
+     * Subsequently `onCounterpartyMembershipVerified` can be used.
      */
 
     @Suspendable

--- a/bn-apps/ledger-sync/ledger-sync-service/src/test/kotlin/net/corda/businessnetworks/ledgersync/LedgerConsistencyTests.kt
+++ b/bn-apps/ledger-sync/ledger-sync-service/src/test/kotlin/net/corda/businessnetworks/ledgersync/LedgerConsistencyTests.kt
@@ -205,7 +205,7 @@ class LedgerConsistencyTests {
     }
 
     private fun StartedNode<MockNode>.members(): List<Party> {
-        val future = services.startFlow(GetMembershipsFlow<Any>(true)).resultFuture
+        val future = services.startFlow(GetMembershipsFlow(true)).resultFuture
         mockNetwork.runNetwork()
         return future.getOrThrow().keys.toList()
     }

--- a/bn-apps/ledger-sync/ledger-sync-service/src/test/kotlin/net/corda/businessnetworks/ledgersync/LedgerConsistencyTests.kt
+++ b/bn-apps/ledger-sync/ledger-sync-service/src/test/kotlin/net/corda/businessnetworks/ledgersync/LedgerConsistencyTests.kt
@@ -3,8 +3,8 @@ package net.corda.businessnetworks.ledgersync
 import net.corda.businessnetworks.membership.bno.ActivateMembershipFlow
 import net.corda.businessnetworks.membership.member.GetMembershipsFlow
 import net.corda.businessnetworks.membership.member.RequestMembershipFlow
-import net.corda.businessnetworks.membership.states.Membership
-import net.corda.businessnetworks.membership.states.MembershipMetadata
+import net.corda.businessnetworks.membership.states.MembershipState
+import net.corda.businessnetworks.membership.states.SimpleMembershipMetadata
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
@@ -170,17 +170,17 @@ class LedgerConsistencyTests {
     }
 
     private fun StartedNode<MockNode>.elevateToMember() {
-        val membershipRequest = runRequestMembershipFlow().coreTransaction.outRef<Membership.State>(0)
+        val membershipRequest = runRequestMembershipFlow().coreTransaction.outRef<MembershipState<Any>>(0)
         bno.fromNetwork().runActivateMembershipFlow(membershipRequest)
     }
 
     private fun StartedNode<MockNode>.runRequestMembershipFlow(): SignedTransaction {
-        val future = services.startFlow(RequestMembershipFlow(MembershipMetadata("DEFAULT"))).resultFuture
+        val future = services.startFlow(RequestMembershipFlow(SimpleMembershipMetadata("DEFAULT"))).resultFuture
         mockNetwork.runNetwork()
         return future.getOrThrow()
     }
 
-    private fun StartedNode<MockNode>.runActivateMembershipFlow(membership: StateAndRef<Membership.State>): SignedTransaction {
+    private fun StartedNode<MockNode>.runActivateMembershipFlow(membership: StateAndRef<MembershipState<Any>>): SignedTransaction {
         val future = services.startFlow(ActivateMembershipFlow(membership)).resultFuture
         mockNetwork.runNetwork()
         return future.getOrThrow()
@@ -205,7 +205,7 @@ class LedgerConsistencyTests {
     }
 
     private fun StartedNode<MockNode>.members(): List<Party> {
-        val future = services.startFlow(GetMembershipsFlow(true)).resultFuture
+        val future = services.startFlow(GetMembershipsFlow<Any>(true)).resultFuture
         mockNetwork.runNetwork()
         return future.getOrThrow().keys.toList()
     }

--- a/bn-apps/memberships-management/README.md
+++ b/bn-apps/memberships-management/README.md
@@ -1,20 +1,52 @@
 ![Corda](https://www.corda.net/wp-content/uploads/2016/11/fg005_corda_b.png)
 
-# Business Network Membership Service
+# Business Network Membership Service (BNMS)
 
-This is a reference implementation for the Business Network Membership Service. The implementation can, but doesn't have to be used as-is. Business Networks are encouraged to tweak the code to fit their requirements.
+This is a reference implementation for the Business Network Membership Service. 
 
 Please see the [design doc](./design/design.md) for more information about the problem this service is aimed to tackle. 
 
+## Structure
+
+BNMS provides generic implementations of flows, states and contracts to model memberships on a Business Network.
+
 BNMS consists of 2 CorDapps:
 * `membership-service-contracts-and-states` - contracts and states
-* `membership-service` - flows for both BNO and members
+* `membership-service` - flows for both BNO and member CorDapps 
 
 Both of the CorDapps are required to be installed to the nodes of all Business Network participants as well as to the BNO's node.
 
-CorDapp configuration is red from `cordapps/config/membership-service.conf` file with a fallback to `membership-service.conf` on the CorDapp's classpath.
+### States
 
-Please see [FullBNMSFlowDemo](./membership-service/src/test/kotlin/net/corda/businessnetworks/membership/FullBNMSFlowDemo.kt) for how-to-use example.
+Memberships are represented with a `MembershipState`. Users can associate a custom metadata with their `MembershipState` via `membershipMetadata` field. `MembershipState` is generic and doesn't enforce any restrictions over the type of the metadata.
+
+`MembershipState` can exist in the following statuses: 
+* `PENDING` - the very first status of each membership. To be able to transact on the Business Network `PENDING` memberships need to be activated first.
+* `ACTIVE` - active membership holders can transact on the Business Network.
+* `SUSPENDED` - Business Network members can be temporarily suspended by their BNO as a result of a governance action for example. Suspended members can't transact on the Business Network.
+
+### Membership contract
+
+`MembershipState` evolution is curated by `MembershipContract`. However, `MembershipContract` can't verify evolution of the membership metadata as it's a generic parameter.   
+
+Membership metadata evoltion can be verified in the following ways:
+* In the responding flows, by overriding them at the BNO's side (_off-ledger verification_). Will be introduced in Corda 4.
+* By extending the functionality provided by the `MembershipContract` (_on-ledger verification_). `MembershipContract` is an `open` class and can be extended by users to add any custom verification logic. A custom contract implementation can be provided to the BNMS via `membershipContractName` configuration property of the BNO's CorDapp.
+
+### Flows
+
+BNMS flows are split in 2 packages `bno` and `member` - with the flows for BNOs and members respectively.
+
+Flows that can be invoked by members: 
+* `RequestMembershipFlow` - to request a membership. 
+* `AmendMembershipMetadataFlow` - to update a membership metadata
+* `GetMembershipsFlow` - to pull memberships list from the BNO. Members retrieve a full memberships list from the BNO on the first invocation of `GetMembershipsFlow` and then cache it in memory. All subsequent updates to the memberships are delivered via push. Memberships cache can be force-refreshed by setting `forceRefresh` of `GetMembershipsFlow` to true. Members that are missing from the Network Map are filtered out from the result list.
+
+Flows that can be invoked by BNO: 
+* `ActivateMembershipFlow` - to activate a `PENDING` membership
+* `SuspendMembershipFlow` - to suspend an `ACTIVE` membership
+
+Please see [FullBNMSFlowDemo](./membership-service/src/test/kotlin/net/corda/businessnetworks/membership/FullBNMSFlowDemo.kt) for a detailed how-to-use example.
 
 Note that during development you can take advantage of the following classes that encapsulate some commonly used logic:
 * If you are a business network operator: `BusinessNetworkOperatorFlowLogic` and `BusinessNetworkOperatorInitiatedFlow`
@@ -22,26 +54,29 @@ Note that during development you can take advantage of the following classes tha
 
 Look at their respective class annotations for details.
 
-> By default membership states for parties that don't exist in the Network Map are not considered as valid. To change this behaviour please see `GetMembershipsFlow.filterOutNotExisting` flag. 
+If you don't want to manually activate every membership request and would like to instead automate the process then implement the interface `MembershipAutoAcceptor` and add a respective entry to the BNO's configuration file.
 
-## Member configuration 
+## Configuration 
 
-| Property        | Description         |
-| ------------- |:-------------:|
-| `bnoName` | Fully qualified X500 name of the BNO |
+CorDapp configuration is red from `cordapps/config/membership-service.conf` file with a fallback to `membership-service.conf` on the CorDapp's classpath.
 
-## BNO configuration 
+### Member configuration
 
-| Property        | Description         |
-| ------------- |:-------------:|
-| `notaryName` | Fully qualified X500 name of the Notary to be used for membership states notarisation|
-| `cacheRefreshPeriod` | Specifies how often (in milliseconds) BN members should be refreshing their membership list caches. If this attribute is not set, then the BN members will pull membership list only once, when their node starts, and then will rely on the BNO to notify them about all memberships changes.|
-| `notificationsEnabled` | If `true`, then the BNO will notify all members about any change to the memberships |
+```hocon
+// X500 name of the BNO
+bnoName = "O=BNO,L=New York,C=US"
+``` 
 
-## Behaviour customization
+### BNO configuration
+```hocon
+// Name of the Notary
+notaryName = "O=Notary,L=Longon,C=GB"
 
-If you don't want to manually activate every membership request and would like to instead automate the process then implement the interface `MembershipAutoAcceptor`. Then add a new entry into the membership-service.properties file
+// Name of the contract to validate membership transactions with. 
+// Defaults to "net.corda.businessnetworks.membership.states.MembershipContract" if not specified
+membershipContractName = "com.app.MyMembershipContract"
 
-| Property        | Description         |
-| ------------- |:-------------:|
-| `membershipAutoAcceptor` | Class implementing the MembershipAutoAcceptor interface, including package name |
+// Name of the class that implements MembershipAutoAcceptor interface. Optional parameter.
+membershipAutoAcceptor = "com.app.MyMembershipAutoAcceptor"
+
+``` 

--- a/bn-apps/memberships-management/membership-service-contracts-and-states/src/main/kotlin/net/corda/businessnetworks/membership/states/Membership.kt
+++ b/bn-apps/memberships-management/membership-service-contracts-and-states/src/main/kotlin/net/corda/businessnetworks/membership/states/Membership.kt
@@ -1,8 +1,10 @@
 package net.corda.businessnetworks.membership.states
 
 import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.CommandWithParties
 import net.corda.core.contracts.Contract
 import net.corda.core.contracts.LinearState
+import net.corda.core.contracts.Requirements.using
 import net.corda.core.contracts.TypeOnlyCommandData
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.contracts.requireSingleCommand
@@ -16,9 +18,21 @@ import net.corda.core.transactions.LedgerTransaction
 import java.time.Instant
 
 /**
- * Contracts that verifies evolution of the Membership States
+ * Contracts that verifies an evolution of [MembershipState]s. Only an evolution of [MembershipState]s is verified, not of their metadata.
+ * To verify evolution of a membership metadata, users can:
+ * 1. override responding flows at the BNO's side and put a custom verification logic in there (off-ledger verification)
+ * 2. override [MembershipContract] and add a custom verification logic into a new contract (on-ledger verification), for example:
+ *
+ * class MyMembershipContract : MembershipContract {
+ *  // ........
+ *
+ *  override fun verifyAmend(tx : LedgerTransaction, command : CommandWithParties<Commands>, outputMembership : MembershipState<*>, inputMembership : MembershipState<*>) {
+ *      super.verifyAmend(tx, command, outputMembership, inputMembership)
+ *      // custom logic goes in here
+ *  }
+ * }
  */
-class MembershipContract : Contract {
+open class MembershipContract : Contract {
     companion object {
         const val CONTRACT_NAME = "net.corda.businessnetworks.membership.states.MembershipContract"
     }
@@ -32,66 +46,62 @@ class MembershipContract : Contract {
 
     override fun verify(tx : LedgerTransaction) {
         val command = tx.commands.requireSingleCommand<Commands>()
-        val output = tx.outputs.single()
-        val outputState = output.data as MembershipState<*>
+        val outputMembership = tx.outputsOfType<MembershipState<*>>().single()
 
         requireThat {
-            "Modified date has to be greater or equal to the issued date" using (outputState.modified >= outputState.issued)
-            "Both BNO and member have to be participants" using (outputState.participants.toSet() == setOf(outputState.member, outputState.bno))
-            "Output state has to be validated with $CONTRACT_NAME" using (output.contract == CONTRACT_NAME)
+            "Modified date has to be greater or equal to the issued date" using (outputMembership.modified >= outputMembership.issued)
+            "Both BNO and member have to be participants" using (outputMembership.participants.toSet() == setOf(outputMembership.member, outputMembership.bno))
             if (!tx.inputs.isEmpty()) {
                 val input = tx.inputs.single()
                 val inputState = input.state.data as MembershipState<*>
-                "Participants of input and output states should be the same" using (outputState.participants.toSet() == input.state.data.participants.toSet())
+                "Participants of input and output states should be the same" using (outputMembership.participants.toSet() == input.state.data.participants.toSet())
                 "Input state has to be validated with $CONTRACT_NAME" using (input.state.contract == CONTRACT_NAME)
-                "Input and output states should have the same issued dates" using (inputState.issued == outputState.issued)
-                "Input and output states should have the same linear IDs" using (inputState.linearId == outputState.linearId)
-                "Output state's modified timestamp should be greater than input's" using (outputState.modified > inputState.modified)
+                "Input and output states should have the same issued dates" using (inputState.issued == outputMembership.issued)
+                "Input and output states should have the same linear IDs" using (inputState.linearId == outputMembership.linearId)
+                "Output state's modified timestamp should be greater than input's" using (outputMembership.modified > inputState.modified)
             }
         }
 
         when (command.value) {
-            is Commands.Request -> requireThat {
-                "Both BNO and member have to sign a membership request transaction" using (command.signers.toSet() == outputState.participants.map { it.owningKey }.toSet() )
-                "Membership request transaction shouldn't contain any inputs" using (tx.inputs.isEmpty())
-                "Membership request transaction should contain an output state in PENDING status" using (outputState.isPending())
-            }
-            is Commands.Suspend -> requireThat {
-                val inputStateAndRef = tx.inputs.single()
-                val inputState = inputStateAndRef.state.data as MembershipState<*>
-                "Only BNO should sign a revocation transaction" using (command.signers.toSet() == setOf(outputState.bno.owningKey))
-                "Input state of a revocation transaction shouldn't be already revoked" using (!inputState.isSuspended())
-                "Output state of a revocation transaction should be revoked" using (outputState.isSuspended())
-                "Input and output states of a revocation transaction should have the same metadata" using (inputState.membershipMetadata == outputState.membershipMetadata)
-            }
-            is Commands.Activate -> requireThat {
-                val inputStateAndRef = tx.inputs.single()
-                val inputState = inputStateAndRef.state.data as MembershipState<*>
-                "Only BNO should sign a membership activation transaction" using (command.signers.toSet() == setOf(outputState.bno.owningKey))
-                "Input state of a membership activation transaction shouldn't be already active" using (!inputState.isActive())
-                "Output state of a membership activation transaction should be active" using (outputState.isActive())
-                "Input and output states of a membership activation transaction should have the same metadata" using (inputState.membershipMetadata == outputState.membershipMetadata)
-            }
-            is Commands.Amend -> requireThat {
-                val inputStateAndRef = tx.inputs.single()
-                val inputState = inputStateAndRef.state.data as MembershipState<*>
-                "Both BNO and member have to sign a metadata amendment transaction" using (command.signers.toSet() == outputState.participants.map { it.owningKey }.toSet() )
-                "Both input and output states of a metadata amendment transaction should be active" using (inputState.isActive() && outputState.isActive())
-                "Input and output states of an amendment transaction should have different membership metadata" using (inputState.membershipMetadata != outputState.membershipMetadata)
-            }
+            is Commands.Request -> verifyRequest(tx, command, outputMembership)
+            is Commands.Suspend -> verifySuspend(tx, command, outputMembership, tx.inputsOfType<MembershipState<*>>().single())
+            is Commands.Activate -> verifyActivate(tx, command, outputMembership, tx.inputsOfType<MembershipState<*>>().single())
+            is Commands.Amend -> verifyAmend(tx, command, outputMembership, tx.inputsOfType<MembershipState<*>>().single())
             else -> throw IllegalArgumentException("Unsupported command ${command.value}")
         }
     }
 
+    open fun verifyRequest(tx : LedgerTransaction, command : CommandWithParties<Commands>, outputMembership : MembershipState<*>) = requireThat {
+        "Both BNO and member have to sign a membership request transaction" using (command.signers.toSet() == outputMembership.participants.map { it.owningKey }.toSet() )
+        "Membership request transaction shouldn't contain any inputs" using (tx.inputs.isEmpty())
+        "Membership request transaction should contain an output state in PENDING status" using (outputMembership.isPending())
+    }
+
+    open fun verifySuspend(tx : LedgerTransaction, command : CommandWithParties<Commands>, outputMembership : MembershipState<*>, inputMembership : MembershipState<*>) {
+        "Only BNO should sign a suspension transaction" using (command.signers.toSet() == setOf(outputMembership.bno.owningKey))
+        "Input state of a suspension transaction shouldn't be already suspended" using (!inputMembership.isSuspended())
+        "Output state of a suspension transaction should be suspended" using (outputMembership.isSuspended())
+        "Input and output states of a suspension transaction should have the same metadata" using (inputMembership.membershipMetadata == outputMembership.membershipMetadata)
+    }
+
+    open fun verifyActivate(tx : LedgerTransaction, command : CommandWithParties<Commands>, outputMembership : MembershipState<*>, inputMembership : MembershipState<*>) {
+        "Only BNO should sign a membership activation transaction" using (command.signers.toSet() == setOf(outputMembership.bno.owningKey))
+        "Input state of a membership activation transaction shouldn't be already active" using (!inputMembership.isActive())
+        "Output state of a membership activation transaction should be active" using (outputMembership.isActive())
+        "Input and output states of a membership activation transaction should have the same metadata" using (inputMembership.membershipMetadata == outputMembership.membershipMetadata)
+    }
+
+    open fun verifyAmend(tx : LedgerTransaction, command : CommandWithParties<Commands>, outputMembership : MembershipState<*>, inputMembership : MembershipState<*>) = requireThat {
+        "Both BNO and member have to sign a metadata amendment transaction" using (command.signers.toSet() == outputMembership.participants.map { it.owningKey }.toSet() )
+        "Both input and output states of a metadata amendment transaction should be active" using (inputMembership.isActive() && outputMembership.isActive())
+        "Input and output states of an amendment transaction should have different membership metadata" using (inputMembership.membershipMetadata != outputMembership.membershipMetadata)
+        "Input and output states's metadata of an amendment transaction should be of the same type" using (inputMembership.membershipMetadata.javaClass == outputMembership.membershipMetadata.javaClass)
+    }
 }
 
-
 /**
- * This state represents a membership on the ledger. It supports user defined extensions via [membershipMetadata].
- * Users can associate any custom metadata objects with their Membership States and store it on the ledger. For example:
- *
- * @CordaSerializable
- * data class MyMembershipMetadata (val role : String, val email : String, val address : String)
+ * Represents a membership on the ledger. Supports user defined extensions via [membershipMetadata].
+ * Users can associate any custom metadata object with their [MembershipState], which will be recorded on the ledger.
  *
  * @param member identity of a member
  * @param bno identity of the BNO
@@ -99,7 +109,7 @@ class MembershipContract : Contract {
  * @param modified timestamp when the state has been modified the last time
  * @param status status of the state, i.e. ACTIVE, SUSPENDED, PENDING etc.
  */
-data class MembershipState<out T>(val member : Party,
+data class MembershipState<out T : Any>(val member : Party,
                               val bno : Party,
                               val membershipMetadata : T,
                               val issued : Instant = Instant.now(),
@@ -123,7 +133,7 @@ data class MembershipState<out T>(val member : Party,
 }
 
 /**
- * Statuses that membership can go through.
+ * Statuses that a membership can go through.
  *
  * [PENDING] - newly submitted state, haven't been approved yet. Pending members can't transact on the Business Network
  * [ACTIVE] - active members can transact on the Business Network
@@ -135,7 +145,7 @@ enum class MembershipStatus {
 }
 
 /**
- * Simple metadata, that assigns a role with membership state
+ * Simple metadata example.
  */
 @CordaSerializable
-data class SimpleMembershipMetadata(val role : String)
+data class SimpleMembershipMetadata(val role : String = "", val humanReadableName : String = "")

--- a/bn-apps/memberships-management/membership-service-contracts-and-states/src/main/kotlin/net/corda/businessnetworks/membership/states/Membership.kt
+++ b/bn-apps/memberships-management/membership-service-contracts-and-states/src/main/kotlin/net/corda/businessnetworks/membership/states/Membership.kt
@@ -15,34 +15,37 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.LedgerTransaction
 import java.time.Instant
 
-class Membership : Contract {
+/**
+ * Contracts that verifies evolution of the Membership States
+ */
+class MembershipContract : Contract {
     companion object {
-        val CONTRACT_NAME = "net.corda.businessnetworks.membership.states.Membership"
+        const val CONTRACT_NAME = "net.corda.businessnetworks.membership.states.MembershipContract"
     }
 
     open class Commands : CommandData, TypeOnlyCommandData() {
         class Request : Commands()
         class Amend : Commands()
-        class Revoke : Commands()
+        class Suspend : Commands()
         class Activate : Commands()
     }
 
     override fun verify(tx : LedgerTransaction) {
         val command = tx.commands.requireSingleCommand<Commands>()
         val output = tx.outputs.single()
-        val outputState = output.data as State
+        val outputState = output.data as MembershipState<*>
 
         requireThat {
-            "Modified date has to be greater or equal than the issued date" using (outputState.modified >= outputState.issued)
+            "Modified date has to be greater or equal to the issued date" using (outputState.modified >= outputState.issued)
             "Both BNO and member have to be participants" using (outputState.participants.toSet() == setOf(outputState.member, outputState.bno))
             "Output state has to be validated with $CONTRACT_NAME" using (output.contract == CONTRACT_NAME)
             if (!tx.inputs.isEmpty()) {
                 val input = tx.inputs.single()
-                val inputState = input.state.data as State
+                val inputState = input.state.data as MembershipState<*>
                 "Participants of input and output states should be the same" using (outputState.participants.toSet() == input.state.data.participants.toSet())
                 "Input state has to be validated with $CONTRACT_NAME" using (input.state.contract == CONTRACT_NAME)
                 "Input and output states should have the same issued dates" using (inputState.issued == outputState.issued)
-                "Input and output states should have the same linear ids" using (inputState.linearId == outputState.linearId)
+                "Input and output states should have the same linear IDs" using (inputState.linearId == outputState.linearId)
                 "Output state's modified timestamp should be greater than input's" using (outputState.modified > inputState.modified)
             }
         }
@@ -53,17 +56,17 @@ class Membership : Contract {
                 "Membership request transaction shouldn't contain any inputs" using (tx.inputs.isEmpty())
                 "Membership request transaction should contain an output state in PENDING status" using (outputState.isPending())
             }
-            is Commands.Revoke -> requireThat {
+            is Commands.Suspend -> requireThat {
                 val inputStateAndRef = tx.inputs.single()
-                val inputState = inputStateAndRef.state.data as State
+                val inputState = inputStateAndRef.state.data as MembershipState<*>
                 "Only BNO should sign a revocation transaction" using (command.signers.toSet() == setOf(outputState.bno.owningKey))
-                "Input state of a revocation transaction shouldn't be already revoked" using (!inputState.isRevoked())
-                "Output state of a revocation transaction should be revoked" using (outputState.isRevoked())
+                "Input state of a revocation transaction shouldn't be already revoked" using (!inputState.isSuspended())
+                "Output state of a revocation transaction should be revoked" using (outputState.isSuspended())
                 "Input and output states of a revocation transaction should have the same metadata" using (inputState.membershipMetadata == outputState.membershipMetadata)
             }
             is Commands.Activate -> requireThat {
                 val inputStateAndRef = tx.inputs.single()
-                val inputState = inputStateAndRef.state.data as State
+                val inputState = inputStateAndRef.state.data as MembershipState<*>
                 "Only BNO should sign a membership activation transaction" using (command.signers.toSet() == setOf(outputState.bno.owningKey))
                 "Input state of a membership activation transaction shouldn't be already active" using (!inputState.isActive())
                 "Output state of a membership activation transaction should be active" using (outputState.isActive())
@@ -71,7 +74,7 @@ class Membership : Contract {
             }
             is Commands.Amend -> requireThat {
                 val inputStateAndRef = tx.inputs.single()
-                val inputState = inputStateAndRef.state.data as State
+                val inputState = inputStateAndRef.state.data as MembershipState<*>
                 "Both BNO and member have to sign a metadata amendment transaction" using (command.signers.toSet() == outputState.participants.map { it.owningKey }.toSet() )
                 "Both input and output states of a metadata amendment transaction should be active" using (inputState.isActive() && outputState.isActive())
                 "Input and output states of an amendment transaction should have different membership metadata" using (inputState.membershipMetadata != outputState.membershipMetadata)
@@ -80,39 +83,59 @@ class Membership : Contract {
         }
     }
 
-
-    data class State(val member : Party,
-                     val bno : Party,
-                     val membershipMetadata : MembershipMetadata = MembershipMetadata(),
-                     val issued : Instant = Instant.now(),
-                     val modified : Instant = issued,
-                     val status : MembershipStatus = MembershipStatus.PENDING,
-                     override val linearId : UniqueIdentifier = UniqueIdentifier()) : LinearState, QueryableState {
-        override fun generateMappedObject(schema : MappedSchema) : PersistentState {
-            return when (schema) {
-                is MembershipStateSchemaV1 -> MembershipStateSchemaV1.PersistentMembershipState(
-                        member = this.member,
-                        status = this.status
-                )
-                else -> throw IllegalArgumentException("Unrecognised schema $schema")
-            }
-        }
-        override fun supportedSchemas() = listOf(MembershipStateSchemaV1)
-        override val participants = listOf(bno, member)
-        fun isRevoked() = status == MembershipStatus.REVOKED
-        fun isPending() = status == MembershipStatus.PENDING
-        fun isActive() = status == MembershipStatus.ACTIVE
-    }
 }
 
-@CordaSerializable
-data class MembershipMetadata(
-        val role : String = "",
-        val alternativeName : String? = null
-        // add more fields here
-)
 
+/**
+ * This state represents a membership on the ledger. It supports user defined extensions via [membershipMetadata].
+ * Users can associate any custom metadata objects with their Membership States and store it on the ledger. For example:
+ *
+ * @CordaSerializable
+ * data class MyMembershipMetadata (val role : String, val email : String, val address : String)
+ *
+ * @param member identity of a member
+ * @param bno identity of the BNO
+ * @param issued timestamp when the state has been issued
+ * @param modified timestamp when the state has been modified the last time
+ * @param status status of the state, i.e. ACTIVE, SUSPENDED, PENDING etc.
+ */
+data class MembershipState<out T>(val member : Party,
+                              val bno : Party,
+                              val membershipMetadata : T,
+                              val issued : Instant = Instant.now(),
+                              val modified : Instant = issued,
+                              val status : MembershipStatus = MembershipStatus.PENDING,
+                              override val linearId : UniqueIdentifier = UniqueIdentifier()) : LinearState, QueryableState {
+    override fun generateMappedObject(schema : MappedSchema) : PersistentState {
+        return when (schema) {
+            is MembershipStateSchemaV1 -> MembershipStateSchemaV1.PersistentMembershipState(
+                    member = this.member,
+                    status = this.status
+            )
+            else -> throw IllegalArgumentException("Unrecognised schema $schema")
+        }
+    }
+    override fun supportedSchemas() = listOf(MembershipStateSchemaV1)
+    override val participants = listOf(bno, member)
+    fun isSuspended() = status == MembershipStatus.SUSPENDED
+    fun isPending() = status == MembershipStatus.PENDING
+    fun isActive() = status == MembershipStatus.ACTIVE
+}
+
+/**
+ * Statuses that membership can go through.
+ *
+ * [PENDING] - newly submitted state, haven't been approved yet. Pending members can't transact on the Business Network
+ * [ACTIVE] - active members can transact on the Business Network
+ * [SUSPENDED] - suspended members can't transact on the Business Network. Suspended members can be activated back.
+ */
 @CordaSerializable
 enum class MembershipStatus {
-    PENDING, ACTIVE, REVOKED
+    PENDING, ACTIVE, SUSPENDED
 }
+
+/**
+ * Simple metadata, that assigns a role with membership state
+ */
+@CordaSerializable
+data class SimpleMembershipMetadata(val role : String)

--- a/bn-apps/memberships-management/membership-service-contracts-and-states/src/main/kotlin/net/corda/businessnetworks/membership/states/Schemas.kt
+++ b/bn-apps/memberships-management/membership-service-contracts-and-states/src/main/kotlin/net/corda/businessnetworks/membership/states/Schemas.kt
@@ -9,7 +9,7 @@ import javax.persistence.Entity
 import javax.persistence.Table
 
 @CordaSerializable
-object MembershipStateSchemaV1 : MappedSchema(schemaFamily = Membership.State::class.java, version = 1, mappedTypes = listOf(PersistentMembershipState::class.java)) {
+object MembershipStateSchemaV1 : MappedSchema(schemaFamily = MembershipState::class.java, version = 1, mappedTypes = listOf(PersistentMembershipState::class.java)) {
     @Entity
     @Table(name = "membership_states")
     class PersistentMembershipState (

--- a/bn-apps/memberships-management/membership-service-contracts-and-states/src/test/kotlin/net/corda/businessnetworks/membership/states/MembershipContractTest.kt
+++ b/bn-apps/memberships-management/membership-service-contracts-and-states/src/test/kotlin/net/corda/businessnetworks/membership/states/MembershipContractTest.kt
@@ -63,6 +63,13 @@ class MembershipContractTest {
                 this.`fails with`("Input and output states should have the same linear ids")
             }
             transaction {
+                val input = output.copy()
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MyDummyContract.CONTRACT_NAME, output)
+                command(listOf(member.publicKey), MembershipContract.Commands.Request())
+                this.`fails with`("Output state has to be validated with ${MembershipContract.CONTRACT_NAME}")
+            }
+            transaction {
                 val issuedDate = Instant.now()
                 val inputModifiedDate = issuedDate.plusSeconds(10)
                 val outputModifiedDate = issuedDate.plusSeconds(5)

--- a/bn-apps/memberships-management/membership-service-contracts-and-states/src/test/kotlin/net/corda/businessnetworks/membership/states/MembershipContractTest.kt
+++ b/bn-apps/memberships-management/membership-service-contracts-and-states/src/test/kotlin/net/corda/businessnetworks/membership/states/MembershipContractTest.kt
@@ -20,7 +20,8 @@ class MembershipContractTest {
     private val anotherMemberParty = anotherMember.party
     private val bnoParty = bno.party
 
-    private fun membershipState(status : MembershipStatus = MembershipStatus.PENDING, member : Party = memberParty, bno : Party = bnoParty, issued : Instant = Instant.now()) = Membership.State(member, bno, status = status)
+    private fun membershipState(status : MembershipStatus = MembershipStatus.PENDING, member : Party = memberParty, bno : Party = bnoParty, issued : Instant = Instant.now())
+            = MembershipState(member, bno, issued = issued, status = status, membershipMetadata = SimpleMembershipMetadata("test"))
 
 
     @Test
@@ -28,46 +29,46 @@ class MembershipContractTest {
         ledgerServices.ledger {
             val output = membershipState()
             transaction {
-                output(Membership.CONTRACT_NAME,  output.copy(modified = Instant.now().minusSeconds(100)))
-                command(listOf(member.publicKey), Membership.Commands.Request())
-                this.`fails with`("Modified date has to be greater or equal than the issued date")
+                output(MembershipContract.CONTRACT_NAME,  output.copy(modified = Instant.now().minusSeconds(100)))
+                command(listOf(member.publicKey), MembershipContract.Commands.Request())
+                this.`fails with`("Modified date has to be greater or equal to the issued date")
             }
             transaction {
                 val input = output.copy(member = anotherMemberParty)
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  output)
-                command(listOf(member.publicKey), Membership.Commands.Request())
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  output)
+                command(listOf(member.publicKey), MembershipContract.Commands.Request())
                 this.`fails with`("Participants of input and output states should be the same")
             }
             transaction {
                 val input = output.copy()
                 input(MyDummyContract.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME, output )
-                command(listOf(member.publicKey), Membership.Commands.Request())
-                this.`fails with`("Input state has to be validated with ${Membership.CONTRACT_NAME}")
+                output(MembershipContract.CONTRACT_NAME, output )
+                command(listOf(member.publicKey), MembershipContract.Commands.Request())
+                this.`fails with`("Input state has to be validated with ${MembershipContract.CONTRACT_NAME}")
             }
             transaction {
                 val wrongIssuedDate = Instant.now().minusSeconds(100)
                 val input = output.copy(issued = wrongIssuedDate, modified = wrongIssuedDate)
-                input(Membership.CONTRACT_NAME, input)
-                output(Membership.CONTRACT_NAME, output )
-                command(listOf(member.publicKey), Membership.Commands.Request())
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, output )
+                command(listOf(member.publicKey), MembershipContract.Commands.Request())
                 this.`fails with`("Input and output states should have the same issued dates")
             }
             transaction {
                 val input = output.copy(linearId = UniqueIdentifier())
-                input(Membership.CONTRACT_NAME, input)
-                output(Membership.CONTRACT_NAME, output)
-                command(listOf(member.publicKey), Membership.Commands.Request())
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, output)
+                command(listOf(member.publicKey), MembershipContract.Commands.Request())
                 this.`fails with`("Input and output states should have the same linear ids")
             }
             transaction {
                 val issuedDate = Instant.now()
                 val inputModifiedDate = issuedDate.plusSeconds(10)
                 val outputModifiedDate = issuedDate.plusSeconds(5)
-                input(Membership.CONTRACT_NAME, output.copy(issued = issuedDate, modified = inputModifiedDate))
-                output(Membership.CONTRACT_NAME, output.copy(issued = issuedDate, modified = outputModifiedDate))
-                command(listOf(member.publicKey), Membership.Commands.Request())
+                input(MembershipContract.CONTRACT_NAME, output.copy(issued = issuedDate, modified = inputModifiedDate))
+                output(MembershipContract.CONTRACT_NAME, output.copy(issued = issuedDate, modified = outputModifiedDate))
+                command(listOf(member.publicKey), MembershipContract.Commands.Request())
                 this.`fails with`("Output state's modified timestamp should be greater than input's")
             }
         }
@@ -77,25 +78,25 @@ class MembershipContractTest {
     fun `test request membership`() {
         ledgerServices.ledger {
             transaction {
-                output(Membership.CONTRACT_NAME,  membershipState())
-                command(listOf(member.publicKey, bno.publicKey), Membership.Commands.Request())
+                output(MembershipContract.CONTRACT_NAME,  membershipState())
+                command(listOf(member.publicKey, bno.publicKey), MembershipContract.Commands.Request())
                 this.verifies()
             }
             transaction {
-                output(Membership.CONTRACT_NAME,  membershipState())
-                command(listOf(member.publicKey), Membership.Commands.Request())
+                output(MembershipContract.CONTRACT_NAME,  membershipState())
+                command(listOf(member.publicKey), MembershipContract.Commands.Request())
                 this.`fails with`("Both BNO and member have to sign a membership request transaction")
             }
             transaction {
-                output(Membership.CONTRACT_NAME,  membershipState(MembershipStatus.REVOKED))
-                command(listOf(member.publicKey, bno.publicKey), Membership.Commands.Request())
+                output(MembershipContract.CONTRACT_NAME,  membershipState(MembershipStatus.SUSPENDED))
+                command(listOf(member.publicKey, bno.publicKey), MembershipContract.Commands.Request())
                 this.`fails with`("Membership request transaction should contain an output state in PENDING status")
             }
             transaction {
                 val state  = membershipState()
-                input(Membership.CONTRACT_NAME,  state)
-                output(Membership.CONTRACT_NAME,  state.copy(modified = state.modified.plusSeconds(10)))
-                command(listOf(member.publicKey, bno.publicKey), Membership.Commands.Request())
+                input(MembershipContract.CONTRACT_NAME,  state)
+                output(MembershipContract.CONTRACT_NAME,  state.copy(modified = state.modified.plusSeconds(10)))
+                command(listOf(member.publicKey, bno.publicKey), MembershipContract.Commands.Request())
                 this.`fails with`("Membership request transaction shouldn't contain any inputs")
             }
         }
@@ -106,37 +107,37 @@ class MembershipContractTest {
         ledgerServices.ledger {
             transaction {
                 val input = membershipState(MembershipStatus.ACTIVE)
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  input.copy(status = MembershipStatus.REVOKED, modified = input.modified.plusMillis(1)))
-                command(listOf(bno.publicKey), Membership.Commands.Revoke())
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  input.copy(status = MembershipStatus.SUSPENDED, modified = input.modified.plusMillis(1)))
+                command(listOf(bno.publicKey), MembershipContract.Commands.Suspend())
                 this.verifies()
             }
             transaction {
                 val input = membershipState(MembershipStatus.ACTIVE)
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  input.copy(status = MembershipStatus.REVOKED, modified = input.modified.plusMillis(1)))
-                command(listOf(bno.publicKey, member.publicKey), Membership.Commands.Revoke())
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  input.copy(status = MembershipStatus.SUSPENDED, modified = input.modified.plusMillis(1)))
+                command(listOf(bno.publicKey, member.publicKey), MembershipContract.Commands.Suspend())
                 this.`fails with`("Only BNO should sign a revocation transaction")
             }
             transaction {
-                val input = membershipState(MembershipStatus.REVOKED)
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  input.copy(status = MembershipStatus.REVOKED, modified = input.modified.plusMillis(1)))
-                command(listOf(bno.publicKey), Membership.Commands.Revoke())
+                val input = membershipState(MembershipStatus.SUSPENDED)
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  input.copy(status = MembershipStatus.SUSPENDED, modified = input.modified.plusMillis(1)))
+                command(listOf(bno.publicKey), MembershipContract.Commands.Suspend())
                 this.`fails with`("Input state of a revocation transaction shouldn't be already revoked")
             }
             transaction {
                 val input = membershipState(MembershipStatus.ACTIVE)
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  input.copy(status = MembershipStatus.PENDING, modified = input.modified.plusMillis(1)))
-                command(listOf(bno.publicKey), Membership.Commands.Revoke())
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  input.copy(status = MembershipStatus.PENDING, modified = input.modified.plusMillis(1)))
+                command(listOf(bno.publicKey), MembershipContract.Commands.Suspend())
                 this.`fails with`( "Output state of a revocation transaction should be revoked")
             }
             transaction {
                 val input = membershipState(MembershipStatus.ACTIVE)
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  input.copy(status = MembershipStatus.REVOKED, modified = input.modified.plusMillis(1), membershipMetadata = MembershipMetadata(role="Another role")))
-                command(listOf(bno.publicKey), Membership.Commands.Revoke())
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  input.copy(status = MembershipStatus.SUSPENDED, modified = input.modified.plusMillis(1), membershipMetadata = SimpleMembershipMetadata(role="Another role")))
+                command(listOf(bno.publicKey), MembershipContract.Commands.Suspend())
                 this.`fails with`("Input and output states of a revocation transaction should have the same metadata")
             }
         }
@@ -146,38 +147,38 @@ class MembershipContractTest {
     fun `test activate membership`() {
         ledgerServices.ledger {
             transaction {
-                val input = membershipState(MembershipStatus.REVOKED)
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  input.copy(status = MembershipStatus.ACTIVE, modified = input.modified.plusMillis(1)))
-                command(listOf(bno.publicKey), Membership.Commands.Activate())
+                val input = membershipState(MembershipStatus.SUSPENDED)
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  input.copy(status = MembershipStatus.ACTIVE, modified = input.modified.plusMillis(1)))
+                command(listOf(bno.publicKey), MembershipContract.Commands.Activate())
                 this.verifies()
             }
             transaction {
-                val input = membershipState(MembershipStatus.REVOKED)
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  input.copy(status = MembershipStatus.ACTIVE, modified = input.modified.plusMillis(1)))
-                command(listOf(bno.publicKey, member.publicKey), Membership.Commands.Activate())
+                val input = membershipState(MembershipStatus.SUSPENDED)
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  input.copy(status = MembershipStatus.ACTIVE, modified = input.modified.plusMillis(1)))
+                command(listOf(bno.publicKey, member.publicKey), MembershipContract.Commands.Activate())
                 this.`fails with`("Only BNO should sign a membership activation transaction")
             }
             transaction {
                 val input = membershipState(MembershipStatus.ACTIVE)
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  input.copy(status = MembershipStatus.ACTIVE, modified = input.modified.plusMillis(1)))
-                command(listOf(bno.publicKey), Membership.Commands.Activate())
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  input.copy(status = MembershipStatus.ACTIVE, modified = input.modified.plusMillis(1)))
+                command(listOf(bno.publicKey), MembershipContract.Commands.Activate())
                 this.`fails with`("Input state of a membership activation transaction shouldn't be already active")
             }
             transaction {
-                val input = membershipState(MembershipStatus.REVOKED)
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  input.copy(status = MembershipStatus.PENDING, modified = input.modified.plusMillis(1)))
-                command(listOf(bno.publicKey), Membership.Commands.Activate())
+                val input = membershipState(MembershipStatus.SUSPENDED)
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  input.copy(status = MembershipStatus.PENDING, modified = input.modified.plusMillis(1)))
+                command(listOf(bno.publicKey), MembershipContract.Commands.Activate())
                 this.`fails with`("Output state of a membership activation transaction should be active")
             }
             transaction {
-                val input = membershipState(MembershipStatus.REVOKED)
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  input.copy(status = MembershipStatus.ACTIVE, modified = input.modified.plusMillis(1), membershipMetadata = MembershipMetadata(role = "Another metadata")))
-                command(listOf(bno.publicKey), Membership.Commands.Activate())
+                val input = membershipState(MembershipStatus.SUSPENDED)
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  input.copy(status = MembershipStatus.ACTIVE, modified = input.modified.plusMillis(1), membershipMetadata = SimpleMembershipMetadata(role = "Another metadata")))
+                command(listOf(bno.publicKey), MembershipContract.Commands.Activate())
                 this.`fails with`("Input and output states of a membership activation transaction should have the same metadata")
             }
         }
@@ -187,36 +188,36 @@ class MembershipContractTest {
     @Test
     fun `test amend member's metadata`() {
         val input = membershipState(MembershipStatus.ACTIVE)
-        val output = input.copy(status = MembershipStatus.ACTIVE, modified = input.modified.plusMillis(1), membershipMetadata = MembershipMetadata(role ="New metadata"))
+        val output = input.copy(status = MembershipStatus.ACTIVE, modified = input.modified.plusMillis(1), membershipMetadata = SimpleMembershipMetadata(role ="New metadata"))
         ledgerServices.ledger {
             transaction {
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  output)
-                command(listOf(bno.publicKey, member.publicKey), Membership.Commands.Amend())
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  output)
+                command(listOf(bno.publicKey, member.publicKey), MembershipContract.Commands.Amend())
                 this.verifies()
             }
             transaction {
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  output)
-                command(listOf(bno.publicKey), Membership.Commands.Amend())
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  output)
+                command(listOf(bno.publicKey), MembershipContract.Commands.Amend())
                 this.`fails with`("Both BNO and member have to sign a metadata amendment transaction")
             }
             transaction {
-                input(Membership.CONTRACT_NAME,  input.copy(status = MembershipStatus.PENDING))
-                output(Membership.CONTRACT_NAME,  output)
-                command(listOf(bno.publicKey, member.publicKey), Membership.Commands.Amend())
+                input(MembershipContract.CONTRACT_NAME,  input.copy(status = MembershipStatus.PENDING))
+                output(MembershipContract.CONTRACT_NAME,  output)
+                command(listOf(bno.publicKey, member.publicKey), MembershipContract.Commands.Amend())
                 this.`fails with`("Both input and output states of a metadata amendment transaction should be active")
             }
             transaction {
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  output.copy(status = MembershipStatus.PENDING))
-                command(listOf(bno.publicKey, member.publicKey), Membership.Commands.Amend())
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  output.copy(status = MembershipStatus.PENDING))
+                command(listOf(bno.publicKey, member.publicKey), MembershipContract.Commands.Amend())
                 this.`fails with`("Both input and output states of a metadata amendment transaction should be active")
             }
             transaction {
-                input(Membership.CONTRACT_NAME,  input)
-                output(Membership.CONTRACT_NAME,  output.copy(membershipMetadata = input.membershipMetadata))
-                command(listOf(bno.publicKey, member.publicKey), Membership.Commands.Amend())
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  output.copy(membershipMetadata = input.membershipMetadata))
+                command(listOf(bno.publicKey, member.publicKey), MembershipContract.Commands.Amend())
                 this.`fails with`("Input and output states of an amendment transaction should have different membership metadata")
             }
         }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/Exceptions.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/Exceptions.kt
@@ -1,10 +1,10 @@
 package net.corda.businessnetworks.membership
 
-import net.corda.businessnetworks.membership.states.Membership
+import net.corda.businessnetworks.membership.states.MembershipState
 import net.corda.core.flows.FlowException
 import net.corda.core.identity.Party
 
-class NotAMemberException(val counterParty : Party) : FlowException("Counterparty $counterParty is not a member of this business network")
-class MembershipNotActiveException(val counterParty : Party) : FlowException("Counterparty's $counterParty membership in this business network is not active")
-class NotBNOException(val membership : Membership.State) : FlowException("This node is not the business network operator of this membership")
+class NotAMemberException(val counterparty : Party) : FlowException("Counterparty $counterparty is not a member of this business network")
+class MembershipNotActiveException(val counterparty : Party) : FlowException("Counterparty's $counterparty membership in this business network is not active")
+class NotBNOException(val membership : MembershipState<Any>) : FlowException("This node is not the business network operator of this membership")
 class MembershipNotFound(val party : Party) : FlowException("Membership for party $party not found")

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/ActivateMembershipFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/ActivateMembershipFlow.kt
@@ -15,8 +15,8 @@ import net.corda.core.utilities.ProgressTracker
 
 /**
  * The flow changes status of a PENDING or SUSPENDED membership to ACTIVE. The flow can be started only by BNO. BNO can unilaterally
- * activate membershipMap and no member's signature is required. After the membership is activated, the flow
- * fires-and-forgets [OnMembershipChanged] notification to the business network members.
+ * activate memberships and no member's signature is required. After a membership is activated, the flow
+ * fires-and-forgets [OnMembershipChanged] notification to all business network members.
  *
  * @param membership membership state to be activated
  */
@@ -34,23 +34,21 @@ class ActivateMembershipFlow(val membership : StateAndRef<MembershipState<Any>>)
         val notary = configuration.notaryParty()
         val builder = TransactionBuilder(notary)
                 .addInputState(membership)
-                .addOutputState(membership.state.data.copy(status = MembershipStatus.ACTIVE, modified = serviceHub.clock.instant()), MembershipContract.CONTRACT_NAME)
+                .addOutputState(membership.state.data.copy(status = MembershipStatus.ACTIVE, modified = serviceHub.clock.instant()), configuration.membershipContractName())
                 .addCommand(MembershipContract.Commands.Activate(), ourIdentity.owningKey)
         builder.verify(serviceHub)
         val selfSignedTx = serviceHub.signInitialTransaction(builder)
         val stx = subFlow(FinalityFlow(selfSignedTx))
 
-        // if notifications are enabled - notify BN about the new joiner
-        if (configuration.areNotificationEnabled()) {
-            subFlow(NotifyActiveMembersFlow(OnMembershipActivated(membership)))
-        }
+        // notify members about changes
+        subFlow(NotifyActiveMembersFlow(OnMembershipActivated(membership)))
 
         return stx
     }
 }
 
 /**
- * This is a convenience flow that can be easily used from command line
+ * This is a convenience flow that can be easily used from a command line
  *
  * @param party whose membership state to be activated
  */

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/AmendMembershipMetadataFlowResponder.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/AmendMembershipMetadataFlowResponder.kt
@@ -7,6 +7,8 @@ import net.corda.businessnetworks.membership.bno.support.BusinessNetworkOperator
 import net.corda.businessnetworks.membership.member.AmendMembershipMetadataFlow
 import net.corda.businessnetworks.membership.member.AmendMembershipMetadataRequest
 import net.corda.businessnetworks.membership.states.MembershipContract
+import net.corda.businessnetworks.membership.states.MembershipState
+import net.corda.core.contracts.StateAndRef
 import net.corda.core.flows.CollectSignaturesFlow
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowSession
@@ -14,28 +16,30 @@ import net.corda.core.flows.InitiatedBy
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.unwrap
 
+/**
+ * BNO's responder to the [AmendMembershipMetadataFlow]. Receives an [AmendMembershipMetadataRequest], issues an amend membership transaction
+ * and notifies all business network members via [OnMembershipChanged] when the transaction is finalised. Only ACTIVE embers can
+ * amend their metadata.
+ */
 @InitiatedBy(AmendMembershipMetadataFlow::class)
 class AmendMembershipMetadataFlowResponder(flowSession : FlowSession) : BusinessNetworkOperatorInitiatedFlow<Unit>(flowSession) {
 
     @Suspendable
-    override fun onOtherPartyMembershipVerified() {
+    override fun onCounterpartyMembershipVerified(counterpartyMembership : StateAndRef<MembershipState<Any>>) {
         // await for a message with a proposed metadata change
         val metadataChangeRequest = flowSession.receive<AmendMembershipMetadataRequest>().unwrap{ it }
 
         // build transaction
         val configuration = serviceHub.cordaService(BNOConfigurationService::class.java)
-        val databaseService = serviceHub.cordaService(DatabaseService::class.java)
         val notaryParty = configuration.notaryParty()
-        val existingMembership = databaseService.getMembership(flowSession.counterparty)!!
 
-        val newMembership = existingMembership.state.data
-                .copy(membershipMetadata = metadataChangeRequest.metadata,
-                        modified = serviceHub.clock.instant())
+        val newMembership = counterpartyMembership.state.data
+                .copy(membershipMetadata = metadataChangeRequest.metadata, modified = serviceHub.clock.instant())
 
         // changes to the metadata should be governed by the contract, not flows
         val builder = TransactionBuilder(notaryParty)
-                .addInputState(existingMembership)
-                .addOutputState(newMembership, MembershipContract.CONTRACT_NAME)
+                .addInputState(counterpartyMembership)
+                .addOutputState(newMembership, configuration.membershipContractName())
                 .addCommand(MembershipContract.Commands.Amend(), flowSession.counterparty.owningKey, ourIdentity.owningKey)
 
         builder.verify(serviceHub)
@@ -44,10 +48,9 @@ class AmendMembershipMetadataFlowResponder(flowSession : FlowSession) : Business
         val allSignedTx = subFlow(CollectSignaturesFlow(selfSignedTx, listOf(flowSession)))
         subFlow(FinalityFlow(allSignedTx))
 
-        // if notifications are enabled - notify the BN members
-        if (configuration.areNotificationEnabled()) {
-            val membershipStateAndRef = databaseService.getMembership(flowSession.counterparty)!!
-            subFlow(NotifyActiveMembersFlow(OnMembershipChanged(membershipStateAndRef)))
-        }
+        // notify members about the changes
+        val databaseService = serviceHub.cordaService(DatabaseService::class.java)
+        val membershipStateAndRef = databaseService.getMembership(flowSession.counterparty)!!
+        subFlow(NotifyActiveMembersFlow(OnMembershipChanged(membershipStateAndRef)))
     }
 }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/AmendMembershipMetadataFlowResponder.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/AmendMembershipMetadataFlowResponder.kt
@@ -6,7 +6,7 @@ import net.corda.businessnetworks.membership.bno.service.DatabaseService
 import net.corda.businessnetworks.membership.bno.support.BusinessNetworkOperatorInitiatedFlow
 import net.corda.businessnetworks.membership.member.AmendMembershipMetadataFlow
 import net.corda.businessnetworks.membership.member.AmendMembershipMetadataRequest
-import net.corda.businessnetworks.membership.states.Membership
+import net.corda.businessnetworks.membership.states.MembershipContract
 import net.corda.core.flows.CollectSignaturesFlow
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowSession
@@ -35,8 +35,8 @@ class AmendMembershipMetadataFlowResponder(flowSession : FlowSession) : Business
         // changes to the metadata should be governed by the contract, not flows
         val builder = TransactionBuilder(notaryParty)
                 .addInputState(existingMembership)
-                .addOutputState(newMembership, Membership.CONTRACT_NAME)
-                .addCommand(Membership.Commands.Amend(), flowSession.counterparty.owningKey, ourIdentity.owningKey)
+                .addOutputState(newMembership, MembershipContract.CONTRACT_NAME)
+                .addCommand(MembershipContract.Commands.Amend(), flowSession.counterparty.owningKey, ourIdentity.owningKey)
 
         builder.verify(serviceHub)
 

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/GetMembershipsFlowResponder.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/GetMembershipsFlowResponder.kt
@@ -1,35 +1,29 @@
 package net.corda.businessnetworks.membership.bno
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.businessnetworks.membership.bno.service.BNOConfigurationService
 import net.corda.businessnetworks.membership.bno.service.DatabaseService
 import net.corda.businessnetworks.membership.bno.support.BusinessNetworkOperatorInitiatedFlow
 import net.corda.businessnetworks.membership.member.GetMembershipsFlow
 import net.corda.businessnetworks.membership.member.MembershipListRequest
 import net.corda.businessnetworks.membership.member.MembershipsListResponse
+import net.corda.businessnetworks.membership.states.MembershipState
+import net.corda.core.contracts.StateAndRef
 import net.corda.core.flows.FlowSession
 import net.corda.core.flows.InitiatedBy
 
 /**
- * Responder to the [GetMembershipsFlow].
+ * Responder to the [GetMembershipsFlow]. Only active members can request a membership list.
  */
 @InitiatedBy(GetMembershipsFlow::class)
 class GetMembershipListFlowResponder(flowSession : FlowSession) : BusinessNetworkOperatorInitiatedFlow<Unit>(flowSession) {
-
     @Suspendable
-    override fun onOtherPartyMembershipVerified() {
-
+    override fun onCounterpartyMembershipVerified(counterpartyMembership : StateAndRef<MembershipState<Any>>) {
         logger.info("Sending membership list to ${flowSession.counterparty}")
         //build memberships snapshot
         flowSession.receive<MembershipListRequest>()
         val databaseService = serviceHub.cordaService(DatabaseService::class.java)
         val memberships = databaseService.getActiveMemberships()
-        val configurationService  = serviceHub.cordaService(BNOConfigurationService::class.java)
-        val cacheRefreshPeriod = configurationService.cacheRefreshPeriod()
 
-        val nextRefreshTime = if (cacheRefreshPeriod == null) null
-            else serviceHub.clock.instant().plusSeconds(cacheRefreshPeriod * 60 * 60)
-
-        flowSession.send(MembershipsListResponse(memberships, nextRefreshTime))
+        flowSession.send(MembershipsListResponse(memberships))
     }
 }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/GetMembershipsFlowResponder.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/GetMembershipsFlowResponder.kt
@@ -18,6 +18,7 @@ class GetMembershipListFlowResponder(flowSession : FlowSession) : BusinessNetwor
 
     @Suspendable
     override fun onOtherPartyMembershipVerified() {
+
         logger.info("Sending membership list to ${flowSession.counterparty}")
         //build memberships snapshot
         flowSession.receive<MembershipListRequest>()
@@ -27,9 +28,8 @@ class GetMembershipListFlowResponder(flowSession : FlowSession) : BusinessNetwor
         val cacheRefreshPeriod = configurationService.cacheRefreshPeriod()
 
         val nextRefreshTime = if (cacheRefreshPeriod == null) null
-            else serviceHub.clock.instant().plusSeconds(cacheRefreshPeriod.toLong() * 60 * 60)
+            else serviceHub.clock.instant().plusSeconds(cacheRefreshPeriod * 60 * 60)
 
         flowSession.send(MembershipsListResponse(memberships, nextRefreshTime))
     }
-
 }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/NotifyMemberFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/NotifyMemberFlow.kt
@@ -2,7 +2,7 @@ package net.corda.businessnetworks.membership.bno
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.businessnetworks.membership.bno.support.BusinessNetworkOperatorFlowLogic
-import net.corda.businessnetworks.membership.states.Membership
+import net.corda.businessnetworks.membership.states.MembershipState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
@@ -10,10 +10,10 @@ import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
 
 @CordaSerializable
-data class OnMembershipActivated(val changedMembership : StateAndRef<Membership.State>)
+data class OnMembershipActivated(val changedMembership : StateAndRef<MembershipState<Any>>)
 
 @CordaSerializable
-data class OnMembershipChanged(val changedMembership : StateAndRef<Membership.State>)
+data class OnMembershipChanged(val changedMembership : StateAndRef<MembershipState<Any>>)
 
 @CordaSerializable
 data class OnMembershipRevoked(val revokedMember : Party)
@@ -25,7 +25,6 @@ class NotifyActiveMembersFlow(private val notification : Any) : BusinessNetworkO
         val memberships = getActiveMembershipStates()
         memberships.forEach { subFlow(NotifyMemberFlow(notification, it.state.data.member)) }
     }
-
 }
 
 @InitiatingFlow

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/NotifyMemberFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/NotifyMemberFlow.kt
@@ -16,10 +16,12 @@ data class OnMembershipActivated(val changedMembership : StateAndRef<MembershipS
 data class OnMembershipChanged(val changedMembership : StateAndRef<MembershipState<Any>>)
 
 @CordaSerializable
-data class OnMembershipRevoked(val revokedMember : Party)
+data class OnMembershipSuspended(val suspendedMember : Party)
 
+/**
+ * Flow that is used by BNO to notify active BN members about changes to the membership list.
+ */
 class NotifyActiveMembersFlow(private val notification : Any) : BusinessNetworkOperatorFlowLogic<Unit>() {
-
     @Suspendable
     override fun call() {
         val memberships = getActiveMembershipStates()
@@ -27,6 +29,9 @@ class NotifyActiveMembersFlow(private val notification : Any) : BusinessNetworkO
     }
 }
 
+/**
+ * Flow that is used by BNO to notify a BN member about changes to the membership list.
+ */
 @InitiatingFlow
 class NotifyMemberFlow(private val notification : Any, private val member : Party) : FlowLogic<Unit>() {
     @Suspendable

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/extension/MembershipAutoAcceptor.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/extension/MembershipAutoAcceptor.kt
@@ -1,7 +1,7 @@
 package net.corda.businessnetworks.membership.bno.extension
 
-import net.corda.businessnetworks.membership.states.Membership
+import net.corda.businessnetworks.membership.states.MembershipState
 
 interface MembershipAutoAcceptor {
-    fun autoActivateThisMembership(membershipState : Membership.State) : Boolean
+    fun autoActivateThisMembership(membershipState : MembershipState<Any>) : Boolean
 }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/extension/MembershipAutoAcceptor.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/extension/MembershipAutoAcceptor.kt
@@ -2,6 +2,12 @@ package net.corda.businessnetworks.membership.bno.extension
 
 import net.corda.businessnetworks.membership.states.MembershipState
 
+/**
+ * Class that, if defined in configuration, is invoked by a BNO against incoming membership requests. If returns true - then the membership would be
+ * activated automatically. The main intention - is to provide an API extension points for BNO for automatic membership verification.
+ *
+ * TODO: remove MembershipAutoAcceptor in favour of flow overrides when Corda 4 is released
+ */
 interface MembershipAutoAcceptor {
     fun autoActivateThisMembership(membershipState : MembershipState<Any>) : Boolean
 }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/service/BNOConfigurationService.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/service/BNOConfigurationService.kt
@@ -12,7 +12,6 @@ import java.io.File
 @CordaService
 class BNOConfigurationService(private val serviceHub : ServiceHub) : SingletonSerializeAsToken() {
     companion object {
-        const val DEFAULT_CACHE_REFRESH_PERIOD = 18000000L
         const val NOTARY_NAME = "notaryName"
         // Specifies how often BN members should be refreshing their membership list caches. If this attribute is not set, then
         // the BN members will pull membership list only once, when their node starts, and then would rely on the BNO to notify them
@@ -30,7 +29,7 @@ class BNOConfigurationService(private val serviceHub : ServiceHub) : SingletonSe
     fun notaryParty() = serviceHub.networkMapCache.getNotary(notaryName())
             ?: throw IllegalArgumentException("Notary ${notaryName()} has not been found on the network")
 
-    fun cacheRefreshPeriod() = if (_config.hasPath(CACHE_REFRESH_PERIOD)) _config.getLong(CACHE_REFRESH_PERIOD) else DEFAULT_CACHE_REFRESH_PERIOD
+    fun cacheRefreshPeriod() = if (_config.hasPath(CACHE_REFRESH_PERIOD)) _config.getLong(CACHE_REFRESH_PERIOD) else null
     fun areNotificationEnabled() = if (_config.hasPath(NOTIFICATIONS_ENABLED)) _config.getBoolean(NOTIFICATIONS_ENABLED) else false
 
     fun getMembershipAutoAcceptor() : MembershipAutoAcceptor? {

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/service/DatabaseService.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/service/DatabaseService.kt
@@ -1,6 +1,6 @@
 package net.corda.businessnetworks.membership.bno.service
 
-import net.corda.businessnetworks.membership.states.Membership
+import net.corda.businessnetworks.membership.states.MembershipState
 import net.corda.businessnetworks.membership.states.MembershipStateSchemaV1
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.identity.Party
@@ -32,18 +32,17 @@ class DatabaseService(val serviceHub : ServiceHub) : SingletonSerializeAsToken()
         session.prepareStatement(nativeQuery).execute()
     }
 
-    fun getMembership(member : Party) : StateAndRef<Membership.State>? {
+    fun getMembership(member : Party) : StateAndRef<MembershipState<Any>>? {
         val memberEqual
                 = builder { MembershipStateSchemaV1.PersistentMembershipState::member.equal(member) }
         val criteria = QueryCriteria.VaultQueryCriteria(Vault.StateStatus.UNCONSUMED)
                 .and(QueryCriteria.VaultCustomQueryCriteria(memberEqual))
-        val states = serviceHub.vaultService.queryBy<Membership.State>(criteria).states
+        val states = serviceHub.vaultService.queryBy<MembershipState<Any>>(criteria).states
         return if (states.isEmpty()) null else (states.sortedBy { it.state.data.modified }.last())
     }
 
-    fun getAllMemberships() = serviceHub.vaultService.queryBy<Membership.State>().states
+    fun getAllMemberships() = serviceHub.vaultService.queryBy<MembershipState<Any>>().states
     fun getActiveMemberships() = getAllMemberships().filter { it.state.data.isActive() }
-
 
     fun createPendingMembershipRequest(party : Party) {
         val nativeQuery = """

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/support/BusinessNetworkOperatorFlowLogic.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/support/BusinessNetworkOperatorFlowLogic.kt
@@ -1,9 +1,9 @@
 package net.corda.businessnetworks.membership.bno.support
 
-import net.corda.businessnetworks.membership.bno.service.DatabaseService
 import net.corda.businessnetworks.membership.MembershipNotFound
 import net.corda.businessnetworks.membership.NotBNOException
-import net.corda.businessnetworks.membership.states.Membership
+import net.corda.businessnetworks.membership.bno.service.DatabaseService
+import net.corda.businessnetworks.membership.states.MembershipState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
@@ -13,20 +13,19 @@ import net.corda.core.identity.Party
  * flows by getting access to the useful methods in this class.
  */
 abstract class BusinessNetworkOperatorFlowLogic<out T> : FlowLogic<T>() {
-
-    protected fun verifyThatWeAreBNO(membership : Membership.State) {
+    protected fun verifyThatWeAreBNO(membership : MembershipState<Any>) {
         if(ourIdentity != membership.bno) {
             throw NotBNOException(membership)
         }
     }
-    protected fun findMembershipStateForParty(party : Party) : StateAndRef<Membership.State> {
+
+    protected fun findMembershipStateForParty(party : Party) : StateAndRef<MembershipState<Any>> {
         val databaseService = serviceHub.cordaService(DatabaseService::class.java)
         return databaseService.getMembership(party) ?: throw MembershipNotFound(party)
     }
 
-    protected fun getActiveMembershipStates() : List<StateAndRef<Membership.State>> {
+    protected fun getActiveMembershipStates() : List<StateAndRef<MembershipState<Any>>> {
         val databaseService = serviceHub.cordaService(DatabaseService::class.java)
         return databaseService.getActiveMemberships()
     }
-
 }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/support/BusinessNetworkOperatorInitiatedFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/bno/support/BusinessNetworkOperatorInitiatedFlow.kt
@@ -4,27 +4,29 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.businessnetworks.membership.bno.service.DatabaseService
 import net.corda.businessnetworks.membership.MembershipNotActiveException
 import net.corda.businessnetworks.membership.NotAMemberException
+import net.corda.businessnetworks.membership.states.MembershipState
+import net.corda.core.contracts.StateAndRef
 import net.corda.core.flows.FlowSession
 import net.corda.core.identity.Party
 
 /**
  * Extend from this class if you are a business network operator and you don't want to be checking yourself whether
- * the initiating party is member of your business network or not. Your code (inside onOtherPartyMembershipVerified)
+ * the initiating party is member of your business network or not. Your code (inside onCounterpartyMembershipVerified)
  * will be called only after the check is performed. If the initiating party is not a member an exception is thrown.
  */
-abstract class BusinessNetworkOperatorInitiatedFlow<out T>(val flowSession: FlowSession) : BusinessNetworkOperatorFlowLogic<T>() {
+abstract class BusinessNetworkOperatorInitiatedFlow<out T>(val flowSession : FlowSession) : BusinessNetworkOperatorFlowLogic<T>() {
 
     @Suspendable
-    override fun call(): T {
-        verifyMembership(flowSession.counterparty)
-        return onOtherPartyMembershipVerified()
+    override fun call() : T {
+        val membership = verifyAndGetMembership(flowSession.counterparty)
+        return onCounterpartyMembershipVerified(membership)
     }
 
     @Suspendable
-    abstract fun onOtherPartyMembershipVerified() : T
+    abstract fun onCounterpartyMembershipVerified(counterpartyMembership : StateAndRef<MembershipState<Any>>) : T
 
     @Suspendable
-    private fun verifyMembership(initiator : Party) {
+    private fun verifyAndGetMembership(initiator : Party) : StateAndRef<MembershipState<Any>> {
         logger.info("Verifying membership status of $initiator")
         val databaseService = serviceHub.cordaService(DatabaseService::class.java)
         val membership = databaseService.getMembership(initiator)
@@ -33,6 +35,7 @@ abstract class BusinessNetworkOperatorInitiatedFlow<out T>(val flowSession: Flow
         } else if (!membership.state.data.isActive()) {
             throw MembershipNotActiveException(initiator)
         }
+        return membership
     }
 }
 

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/AmendMembershipMetadataFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/AmendMembershipMetadataFlow.kt
@@ -45,10 +45,6 @@ class AmendMembershipMetadataFlow(private val newMetadata : Any) : FlowLogic<Sig
                     throw FlowException("Invalid membership state. Wrong BNO's identity ${newMembershipState.bno}.")
                 }
 
-                if (newMembership.contract != MembershipContract.CONTRACT_NAME) {
-                    throw FlowException("Invalid membership state. Wrong contract ${newMembership.contract}")
-                }
-
                 stx.toLedgerTransaction(serviceHub, false).verify()
             }
         }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/AmendMembershipMetadataFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/AmendMembershipMetadataFlow.kt
@@ -2,8 +2,8 @@ package net.corda.businessnetworks.membership.member
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.businessnetworks.membership.member.service.MemberConfigurationService
-import net.corda.businessnetworks.membership.states.MembershipMetadata
-import net.corda.businessnetworks.membership.states.Membership
+import net.corda.businessnetworks.membership.states.MembershipContract
+import net.corda.businessnetworks.membership.states.MembershipState
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
@@ -12,13 +12,13 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 
 @CordaSerializable
-data class AmendMembershipMetadataRequest(val metadata : MembershipMetadata)
+data class AmendMembershipMetadataRequest(val metadata : Any)
 
 /**
  * Proposes a change to the membership metadata
  */
 @InitiatingFlow
-class AmendMembershipMetadataFlow(private val newMetadata : MembershipMetadata) : FlowLogic<SignedTransaction>() {
+class AmendMembershipMetadataFlow(private val newMetadata : Any) : FlowLogic<SignedTransaction>() {
 
     @Suspendable
     override fun call() : SignedTransaction {
@@ -31,9 +31,9 @@ class AmendMembershipMetadataFlow(private val newMetadata : MembershipMetadata) 
         val signTransactionFlow = object : SignTransactionFlow(bnoSession) {
             override fun checkTransaction(stx : SignedTransaction) {
                 val newMembership = stx.coreTransaction.outputs.single()
-                val newMembershipState = newMembership.data as Membership.State
+                val newMembershipState = newMembership.data as MembershipState<*>
 
-                if (stx.tx.commands.single().value !is Membership.Commands.Amend) {
+                if (stx.tx.commands.single().value !is MembershipContract.Commands.Amend) {
                     throw FlowException("Invalid command.")
                 }
 
@@ -45,7 +45,7 @@ class AmendMembershipMetadataFlow(private val newMetadata : MembershipMetadata) 
                     throw FlowException("Invalid membership state. Wrong BNO's identity ${newMembershipState.bno}.")
                 }
 
-                if (newMembership.contract != Membership.CONTRACT_NAME) {
+                if (newMembership.contract != MembershipContract.CONTRACT_NAME) {
                     throw FlowException("Invalid membership state. Wrong contract ${newMembership.contract}")
                 }
 

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/GetMembershipsFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/GetMembershipsFlow.kt
@@ -13,13 +13,12 @@ import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
-import java.time.Instant
 
 @CordaSerializable
 class MembershipListRequest
 
 @CordaSerializable
-data class MembershipsListResponse(val memberships: List<StateAndRef<MembershipState<Any>>>, val expires: Instant? = null)
+data class MembershipsListResponse(val memberships: List<StateAndRef<MembershipState<Any>>>)
 
 /**
  * The flow pulls down a list of active members from the BNO. The list is cached via the [MembershipService].
@@ -49,10 +48,9 @@ class GetMembershipsFlow(private val forceRefresh: Boolean = false, private val 
     override fun call(): Map<Party, StateAndRef<MembershipState<Any>>> {
         val membershipService = serviceHub.cordaService(MembershipsCacheHolder::class.java)
         val cache = membershipService.cache
-        val now = serviceHub.clock.instant()
 
         val membershipsToReturn : Map<Party, StateAndRef<MembershipState<Any>>>
-        if (forceRefresh || cache == null || if (cache.expires == null) false else cache.expires < (now)) {
+        if (forceRefresh || cache == null) {
             val configuration = serviceHub.cordaService(MemberConfigurationService::class.java)
             val bno = configuration.bnoParty()
             val bnoSession = initiateFlow(bno)

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/GetMembershipsFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/GetMembershipsFlow.kt
@@ -4,8 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.businessnetworks.membership.member.service.MemberConfigurationService
 import net.corda.businessnetworks.membership.member.service.MembershipsCache
 import net.corda.businessnetworks.membership.member.service.MembershipsCacheHolder
-import net.corda.businessnetworks.membership.states.Membership
-import net.corda.businessnetworks.membership.states.MembershipMetadata
+import net.corda.businessnetworks.membership.states.MembershipState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
@@ -20,7 +19,7 @@ import java.time.Instant
 class MembershipListRequest
 
 @CordaSerializable
-data class MembershipsListResponse(val memberships: List<StateAndRef<Membership.State>>, val expires: Instant? = null)
+data class MembershipsListResponse(val memberships: List<StateAndRef<MembershipState<Any>>>, val expires: Instant? = null)
 
 /**
  * The flow pulls down a list of active members from the BNO. The list is cached via the [MembershipService].
@@ -44,14 +43,14 @@ data class MembershipsListResponse(val memberships: List<StateAndRef<Membership.
  */
 @InitiatingFlow
 @StartableByRPC
-class GetMembershipsFlow(private val forceRefresh: Boolean = false, private val filterOutNotExisting : Boolean = true) : FlowLogic<Map<Party, StateAndRef<Membership.State>>>() {
+class GetMembershipsFlow<out T>(private val forceRefresh: Boolean = false, private val filterOutNotExisting : Boolean = true) : FlowLogic<Map<Party, StateAndRef<MembershipState<T>>>>() {
     @Suspendable
-    override fun call(): Map<Party, StateAndRef<Membership.State>> {
+    override fun call(): Map<Party, StateAndRef<MembershipState<T>>> {
         val membershipService = serviceHub.cordaService(MembershipsCacheHolder::class.java)
         val cache = membershipService.cache
         val now = serviceHub.clock.instant()
 
-        val membershipsToReturn : Map<Party, StateAndRef<Membership.State>>
+        val membershipsToReturn : Map<Party, StateAndRef<MembershipState<T>>>
         if (forceRefresh || cache == null || if (cache.expires == null) false else cache.expires < (now)) {
             val configuration = serviceHub.cordaService(MemberConfigurationService::class.java)
             val bno = configuration.bnoParty()
@@ -59,36 +58,36 @@ class GetMembershipsFlow(private val forceRefresh: Boolean = false, private val 
             val response = bnoSession.sendAndReceive<MembershipsListResponse>(MembershipListRequest()).unwrap { it }
             val newCache = MembershipsCache.from(response)
             membershipService.cache = newCache
-            membershipsToReturn = newCache.membershipMap.toMap()
+            membershipsToReturn = newCache.membershipMap.mapValues{ it.value as StateAndRef<MembershipState<T>> }
         } else {
-            membershipsToReturn = cache.membershipMap.toMap()
+            membershipsToReturn = cache.membershipMap.mapValues { it.value as StateAndRef<MembershipState<T>> }
         }
 
         return if (filterOutNotExisting) membershipsToReturn.filterOutInactive() else membershipsToReturn
     }
 
-    private fun Map<Party, StateAndRef<Membership.State>>.filterOutInactive() = filter { serviceHub.networkMapCache.getNodeByLegalIdentity(it.key) != null }
+    private fun Map<Party, StateAndRef<MembershipState<T>>>.filterOutInactive() = filter { serviceHub.networkMapCache.getNodeByLegalIdentity(it.key) != null }
 }
 
 @StartableByRPC
-class GetMembersFlow(private val forceRefresh : Boolean = false, private val filterOutNotExisting : Boolean = true) : FlowLogic<List<PartyAndMembershipMetadata>>() {
+class GetMembersFlow<out T>(private val forceRefresh : Boolean = false, private val filterOutNotExisting : Boolean = true) : FlowLogic<List<PartyAndMembershipMetadata<T>>>() {
 
     companion object {
         object GOING_TO_CACHE_OR_BNO : ProgressTracker.Step("Going to cache or BNO for membership data")
 
         fun tracker() = ProgressTracker(
-                GOING_TO_CACHE_OR_BNO
+            GOING_TO_CACHE_OR_BNO
         )
     }
 
     override val progressTracker = tracker()
 
     @Suspendable
-    override fun call(): List<PartyAndMembershipMetadata> {
+    override fun call(): List<PartyAndMembershipMetadata<T>> {
         progressTracker.currentStep = GOING_TO_CACHE_OR_BNO
-        return subFlow(GetMembershipsFlow(forceRefresh, filterOutNotExisting)).map { PartyAndMembershipMetadata(it.key, it.value.state.data.membershipMetadata) }
+        return subFlow(GetMembershipsFlow<T>(forceRefresh, filterOutNotExisting)).map { PartyAndMembershipMetadata(it.key, it.value.state.data.membershipMetadata) }
     }
 }
 
 @CordaSerializable
-data class PartyAndMembershipMetadata(val party : Party, val membershipMetadata: MembershipMetadata)
+data class PartyAndMembershipMetadata<out T>(val party : Party, val membershipMetadata: T)

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/NotifyMembersFlowResponder.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/NotifyMembersFlowResponder.kt
@@ -17,7 +17,7 @@ import net.corda.core.utilities.unwrap
  * Responder to the [NotifyMemberFlow]. The flow updates memberships cache according to a notification from BNO
  */
 @InitiatedBy(NotifyMemberFlow::class)
-class NotifyMembersFlowResponder(val session : FlowSession) : FlowLogic<Unit>(){
+class NotifyMembersFlowResponder(private val session : FlowSession) : FlowLogic<Unit>(){
 
     @Suspendable
     override fun call() {
@@ -48,7 +48,7 @@ class NotifyMembersFlowResponder(val session : FlowSession) : FlowLogic<Unit>(){
                 is OnMembershipActivated -> {
                     // refreshing membership list if its our identity or applying change to the cache otherwise
                     if (notification.changedMembership.state.data.member == ourIdentity) {
-                        subFlow(GetMembershipsFlow<Any>(forceRefresh = true))
+                        subFlow(GetMembershipsFlow(forceRefresh = true))
                     } else {
                         cache.updateMembership(notification.changedMembership)
                     }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/NotifyMembersFlowResponder.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/NotifyMembersFlowResponder.kt
@@ -48,7 +48,7 @@ class NotifyMembersFlowResponder(val session : FlowSession) : FlowLogic<Unit>(){
                 is OnMembershipActivated -> {
                     // refreshing membership list if its our identity or applying change to the cache otherwise
                     if (notification.changedMembership.state.data.member == ourIdentity) {
-                        subFlow(GetMembershipsFlow(true))
+                        subFlow(GetMembershipsFlow<Any>(forceRefresh = true))
                     } else {
                         cache.updateMembership(notification.changedMembership)
                     }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/NotifyMembersFlowResponder.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/NotifyMembersFlowResponder.kt
@@ -4,7 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.businessnetworks.membership.bno.NotifyMemberFlow
 import net.corda.businessnetworks.membership.bno.OnMembershipActivated
 import net.corda.businessnetworks.membership.bno.OnMembershipChanged
-import net.corda.businessnetworks.membership.bno.OnMembershipRevoked
+import net.corda.businessnetworks.membership.bno.OnMembershipSuspended
 import net.corda.businessnetworks.membership.member.service.MemberConfigurationService
 import net.corda.businessnetworks.membership.member.service.MembershipsCacheHolder
 import net.corda.core.flows.FlowException
@@ -14,7 +14,7 @@ import net.corda.core.flows.InitiatedBy
 import net.corda.core.utilities.unwrap
 
 /**
- * Responder to the [NotifyMemberFlow]. The flow updates memberships cache according to a notification from BNO
+ * Responder to the [NotifyMemberFlow]. The flow updates memberships cache with notifications from BNO
  */
 @InitiatedBy(NotifyMemberFlow::class)
 class NotifyMembersFlowResponder(private val session : FlowSession) : FlowLogic<Unit>(){
@@ -31,15 +31,15 @@ class NotifyMembersFlowResponder(private val session : FlowSession) : FlowLogic<
         val cache = membershipService.cache
         if (cache != null) {
             when (notification) {
-            // removes revoked memberships from the cache
-                is OnMembershipRevoked -> {
-                    if (notification.revokedMember != ourIdentity) {
-                        cache.revokeMembership(notification.revokedMember)
+                // removes suspended memberships from the cache
+                is OnMembershipSuspended -> {
+                    if (notification.suspendedMember != ourIdentity) {
+                        cache.suspendMembership(notification.suspendedMember)
                     } else {
                         membershipService.resetCache()
                     }
                 }
-            // updates membership in the cache
+                // updates membership in the cache
                 is OnMembershipChanged -> {
                     if (notification.changedMembership.state.data.member != ourIdentity) {
                         cache.updateMembership(notification.changedMembership)

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/RequestMembershipFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/RequestMembershipFlow.kt
@@ -10,14 +10,14 @@ import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
 
 @CordaSerializable
-data class OnBoardingRequest<out T>(val metadata : T)
+data class OnBoardingRequest(val metadata : Any)
 
 /**
- * The flow requests BNO to kick-off the on-boarding procedure
+ * The flow requests BNO to kick-off the on-boarding procedure.
  */
 @StartableByRPC
 @InitiatingFlow
-class RequestMembershipFlow<T>(private val membershipMetadata : T) : FlowLogic<SignedTransaction>() {
+class RequestMembershipFlow(private val membershipMetadata : Any) : FlowLogic<SignedTransaction>() {
 
     companion object {
         object SENDING_MEMBERSHIP_DATA_TO_BNO : ProgressTracker.Step("Sending membership data to BNO")
@@ -48,10 +48,7 @@ class RequestMembershipFlow<T>(private val membershipMetadata : T) : FlowLogic<S
                 }
 
                 val output = stx.tx.outputs.single()
-                if (output.contract != MembershipContract.CONTRACT_NAME) {
-                    throw FlowException("Output state has to be verified by ${MembershipContract.CONTRACT_NAME}")
-                }
-                val membershipState = output.data as MembershipState<T>
+                val membershipState = output.data as MembershipState<*>
                 if (bno != membershipState.bno) {
                     throw IllegalArgumentException("Wrong BNO identity")
                 }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/RequestMembershipFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/RequestMembershipFlow.kt
@@ -2,22 +2,22 @@ package net.corda.businessnetworks.membership.member
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.businessnetworks.membership.member.service.MemberConfigurationService
-import net.corda.businessnetworks.membership.states.MembershipMetadata
-import net.corda.businessnetworks.membership.states.Membership
+import net.corda.businessnetworks.membership.states.MembershipContract
+import net.corda.businessnetworks.membership.states.MembershipState
 import net.corda.core.flows.*
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
 
 @CordaSerializable
-data class OnBoardingRequest(val metadata : MembershipMetadata)
+data class OnBoardingRequest<out T>(val metadata : T)
 
 /**
  * The flow requests BNO to kick-off the on-boarding procedure
  */
 @StartableByRPC
 @InitiatingFlow
-class RequestMembershipFlow(private val membershipMetadata : MembershipMetadata = MembershipMetadata(role="DEFAULT")) : FlowLogic<SignedTransaction>() {
+class RequestMembershipFlow<T>(private val membershipMetadata : T) : FlowLogic<SignedTransaction>() {
 
     companion object {
         object SENDING_MEMBERSHIP_DATA_TO_BNO : ProgressTracker.Step("Sending membership data to BNO")
@@ -43,15 +43,15 @@ class RequestMembershipFlow(private val membershipMetadata : MembershipMetadata 
         val signResponder = object : SignTransactionFlow(bnoSession) {
             override fun checkTransaction(stx : SignedTransaction) {
                 val command = stx.tx.commands.single()
-                if (command.value !is Membership.Commands.Request) {
+                if (command.value !is MembershipContract.Commands.Request) {
                     throw FlowException("Only Request command is allowed")
                 }
 
                 val output = stx.tx.outputs.single()
-                if (output.contract != Membership.CONTRACT_NAME) {
-                    throw FlowException("Output state has to be verified by ${Membership.CONTRACT_NAME}")
+                if (output.contract != MembershipContract.CONTRACT_NAME) {
+                    throw FlowException("Output state has to be verified by ${MembershipContract.CONTRACT_NAME}")
                 }
-                val membershipState = output.data as Membership.State
+                val membershipState = output.data as MembershipState<T>
                 if (bno != membershipState.bno) {
                     throw IllegalArgumentException("Wrong BNO identity")
                 }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/Utils.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/Utils.kt
@@ -8,6 +8,9 @@ import net.corda.core.utilities.loggerFor
 object Utils {
     val logger = loggerFor<Utils>()
 
+    /**
+     * A convenience method to convert MembershipState<Any> to a MembershipState<T>. All states which metadata is not T will be filtered out.
+     */
     inline fun <reified T : Any> Map<Party, StateAndRef<MembershipState<Any>>>.ofType() = this.filterValues {
         val matches = it.state.data.membershipMetadata is T
         if (!matches) {

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/Utils.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/Utils.kt
@@ -1,0 +1,18 @@
+package net.corda.businessnetworks.membership.member
+
+import net.corda.businessnetworks.membership.states.MembershipState
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.identity.Party
+import net.corda.core.utilities.loggerFor
+
+object Utils {
+    val logger = loggerFor<Utils>()
+
+    inline fun <reified T : Any> Map<Party, StateAndRef<MembershipState<Any>>>.ofType() = this.filterValues {
+        val matches = it.state.data.membershipMetadata is T
+        if (!matches) {
+            logger.warn("Membership ${it.state.data} doesn't match the requested metadata type of ${T::class.java}. Not including into the snapshot.")
+        }
+        matches
+    }.mapValues { it.value as StateAndRef<MembershipState<T>> }
+}

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/service/MemberConfigurationService.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/service/MemberConfigurationService.kt
@@ -6,9 +6,15 @@ import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.CordaService
 import net.corda.core.serialization.SingletonSerializeAsToken
 
+/**
+ * Configuration that is used by member app.
+ *
+ * TODO: remove this class when multiple business networks are supported
+ */
 @CordaService
 class MemberConfigurationService(private val serviceHub : ServiceHub) : SingletonSerializeAsToken() {
     companion object {
+        // X500 name of the BNO
         const val BNO_NAME = "bnoName"
     }
     private val _config = loadConfig()

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/service/MembershipsCache.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/service/MembershipsCache.kt
@@ -7,7 +7,6 @@ import net.corda.core.identity.Party
 import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
 import net.corda.core.serialization.SingletonSerializeAsToken
-import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 
@@ -23,13 +22,12 @@ class MembershipsCacheHolder(private val appServiceHub : AppServiceHub) : Single
     }
 }
 
-class MembershipsCache private constructor(val membershipMap : ConcurrentMap<Party, StateAndRef<MembershipState<Any>>>, val expires : Instant?) {
+class MembershipsCache private constructor(val membershipMap : ConcurrentMap<Party, StateAndRef<MembershipState<Any>>>) {
     companion object {
         fun from(membershipResponse : MembershipsListResponse) = MembershipsCache(
-                ConcurrentHashMap(membershipResponse.memberships.map { it.state.data.member to it }.toMap()),
-                membershipResponse.expires)
+                ConcurrentHashMap(membershipResponse.memberships.map { it.state.data.member to it }.toMap()))
     }
     fun getMembership(party : Party) = membershipMap[party]
-    fun revokeMembership(revokedMember : Party) { membershipMap.remove(revokedMember) }
+    fun suspendMembership(revokedMember : Party) { membershipMap.remove(revokedMember) }
     fun updateMembership(changedMembership : StateAndRef<MembershipState<Any>>) { membershipMap[changedMembership.state.data.member] = changedMembership }
 }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/service/MembershipsCache.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/service/MembershipsCache.kt
@@ -7,7 +7,6 @@ import net.corda.core.identity.Party
 import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
 import net.corda.core.serialization.SingletonSerializeAsToken
-import java.lang.IllegalArgumentException
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
@@ -30,8 +29,7 @@ class MembershipsCache private constructor(val membershipMap : ConcurrentMap<Par
                 ConcurrentHashMap(membershipResponse.memberships.map { it.state.data.member to it }.toMap()),
                 membershipResponse.expires)
     }
-    inline fun <T> getMembership(party : Party) = membershipMap[party] as StateAndRef<MembershipState<T>>?
-
+    fun getMembership(party : Party) = membershipMap[party]
     fun revokeMembership(revokedMember : Party) { membershipMap.remove(revokedMember) }
     fun updateMembership(changedMembership : StateAndRef<MembershipState<Any>>) { membershipMap[changedMembership.state.data.member] = changedMembership }
 }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/service/MembershipsCache.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/service/MembershipsCache.kt
@@ -1,12 +1,13 @@
 package net.corda.businessnetworks.membership.member.service
 
 import net.corda.businessnetworks.membership.member.MembershipsListResponse
-import net.corda.businessnetworks.membership.states.Membership
+import net.corda.businessnetworks.membership.states.MembershipState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.identity.Party
-import net.corda.core.node.ServiceHub
+import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
 import net.corda.core.serialization.SingletonSerializeAsToken
+import java.lang.IllegalArgumentException
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
@@ -15,7 +16,7 @@ import java.util.concurrent.ConcurrentMap
  * A singleton service that holds a cache of memberships
  */
 @CordaService
-class MembershipsCacheHolder(private val serviceHub : ServiceHub) : SingletonSerializeAsToken() {
+class MembershipsCacheHolder(private val appServiceHub : AppServiceHub) : SingletonSerializeAsToken() {
     var cache : MembershipsCache? = null
 
     fun resetCache() {
@@ -23,13 +24,14 @@ class MembershipsCacheHolder(private val serviceHub : ServiceHub) : SingletonSer
     }
 }
 
-class MembershipsCache private constructor(val membershipMap : ConcurrentMap<Party, StateAndRef<Membership.State>>, val expires : Instant?) {
+class MembershipsCache private constructor(val membershipMap : ConcurrentMap<Party, StateAndRef<MembershipState<Any>>>, val expires : Instant?) {
     companion object {
         fun from(membershipResponse : MembershipsListResponse) = MembershipsCache(
                 ConcurrentHashMap(membershipResponse.memberships.map { it.state.data.member to it }.toMap()),
                 membershipResponse.expires)
     }
-    fun getMembership(party : Party) = membershipMap[party]
+    inline fun <T> getMembership(party : Party) = membershipMap[party] as StateAndRef<MembershipState<T>>?
+
     fun revokeMembership(revokedMember : Party) { membershipMap.remove(revokedMember) }
-    fun updateMembership(changedMembership : StateAndRef<Membership.State>) { membershipMap[changedMembership.state.data.member] = changedMembership }
+    fun updateMembership(changedMembership : StateAndRef<MembershipState<Any>>) { membershipMap[changedMembership.state.data.member] = changedMembership }
 }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/support/BusinessNetworkAwareInitiatedFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/support/BusinessNetworkAwareInitiatedFlow.kt
@@ -12,7 +12,7 @@ import net.corda.core.identity.Party
  * the initiating party is also a member. Your code (inside onOtherPartyMembershipVerified) will be called only after
  * that check is performed. If the initiating party is not a member an exception is thrown.
  */
-abstract class BusinessNetworkAwareInitiatedFlow<out T>(val flowSession: FlowSession) : FlowLogic<T>() {
+abstract class BusinessNetworkAwareInitiatedFlow<out T>(private val flowSession: FlowSession) : FlowLogic<T>() {
 
     @Suspendable
     override fun call(): T {
@@ -25,7 +25,7 @@ abstract class BusinessNetworkAwareInitiatedFlow<out T>(val flowSession: FlowSes
 
     @Suspendable
     private fun verifyMembership(initiator : Party) {
-        val memberships = subFlow(GetMembershipsFlow())
+        val memberships = subFlow(GetMembershipsFlow<Any>())
         if(memberships[initiator] == null) {
             throw NotAMemberException(initiator)
         }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/support/BusinessNetworkAwareInitiatedFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/support/BusinessNetworkAwareInitiatedFlow.kt
@@ -25,7 +25,7 @@ abstract class BusinessNetworkAwareInitiatedFlow<out T>(private val flowSession:
 
     @Suspendable
     private fun verifyMembership(initiator : Party) {
-        val memberships = subFlow(GetMembershipsFlow<Any>())
+        val memberships = subFlow(GetMembershipsFlow())
         if(memberships[initiator] == null) {
             throw NotAMemberException(initiator)
         }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/support/BusinessNetworkAwareInitiatedFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/net/corda/businessnetworks/membership/member/support/BusinessNetworkAwareInitiatedFlow.kt
@@ -9,7 +9,7 @@ import net.corda.core.identity.Party
 
 /**
  * Extend from this class if you are a business network member and you don't want to be checking yourself whether
- * the initiating party is also a member. Your code (inside onOtherPartyMembershipVerified) will be called only after
+ * the initiating party is also a member. Your code (inside onCounterpartyMembershipVerified) will be called only after
  * that check is performed. If the initiating party is not a member an exception is thrown.
  */
 abstract class BusinessNetworkAwareInitiatedFlow<out T>(private val flowSession: FlowSession) : FlowLogic<T>() {

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/AbstractFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/AbstractFlowTest.kt
@@ -99,8 +99,8 @@ abstract class AbstractFlowTest(
         return future.getOrThrow()
     }
 
-    fun runGetMembershipsListFlow(nodeToRunTheFlow : StartedMockNode, force : Boolean, filterOutNotExisting : Boolean = true) : Map<Party, StateAndRef<MembershipState<SimpleMembershipMetadata>>> {
-        val future = nodeToRunTheFlow.startFlow(GetMembershipsFlow<SimpleMembershipMetadata>(force, filterOutNotExisting))
+    fun runGetMembershipsListFlow(nodeToRunTheFlow : StartedMockNode, force : Boolean, filterOutNotExisting : Boolean = true) : Map<Party, StateAndRef<MembershipState<Any>>> {
+        val future = nodeToRunTheFlow.startFlow(GetMembershipsFlow(force, filterOutNotExisting))
         mockNetwork.runNetwork()
         return future.getOrThrow()
     }

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/AbstractFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/AbstractFlowTest.kt
@@ -2,8 +2,8 @@ package net.corda.businessnetworks.membership
 
 import net.corda.businessnetworks.membership.bno.ActivateMembershipFlow
 import net.corda.businessnetworks.membership.bno.ActivateMembershipForPartyFlow
-import net.corda.businessnetworks.membership.bno.RevokeMembershipFlow
-import net.corda.businessnetworks.membership.bno.RevokeMembershipForPartyFlow
+import net.corda.businessnetworks.membership.bno.SuspendMembershipFlow
+import net.corda.businessnetworks.membership.bno.SuspendMembershipForPartyFlow
 import net.corda.businessnetworks.membership.member.AmendMembershipMetadataFlow
 import net.corda.businessnetworks.membership.member.GetMembershipsFlow
 import net.corda.businessnetworks.membership.member.RequestMembershipFlow
@@ -67,15 +67,15 @@ abstract class AbstractFlowTest(
         return future.getOrThrow()
     }
 
-    fun runRevokeMembershipFlow(nodeToRunTheFlow : StartedMockNode, party : Party) : SignedTransaction {
+    fun runSuspendMembershipFlow(nodeToRunTheFlow : StartedMockNode, party : Party) : SignedTransaction {
         val membership = getMembership(nodeToRunTheFlow, party)
-        val future = nodeToRunTheFlow.startFlow(RevokeMembershipFlow(membership))
+        val future = nodeToRunTheFlow.startFlow(SuspendMembershipFlow(membership))
         mockNetwork.runNetwork()
         return future.getOrThrow()
     }
 
-    fun runRevokeMembershipForPartyFlow(nodeToRunTheFlow : StartedMockNode, party: Party) : SignedTransaction {
-        val future = nodeToRunTheFlow.startFlow(RevokeMembershipForPartyFlow(party))
+    fun runSuspendMembershipForPartyFlow(nodeToRunTheFlow : StartedMockNode, party: Party) : SignedTransaction {
+        val future = nodeToRunTheFlow.startFlow(SuspendMembershipForPartyFlow(party))
         mockNetwork.runNetwork()
         return future.getOrThrow()
     }

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/AbstractFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/AbstractFlowTest.kt
@@ -8,8 +8,8 @@ import net.corda.businessnetworks.membership.member.AmendMembershipMetadataFlow
 import net.corda.businessnetworks.membership.member.GetMembershipsFlow
 import net.corda.businessnetworks.membership.member.RequestMembershipFlow
 import net.corda.businessnetworks.membership.bno.service.DatabaseService
-import net.corda.businessnetworks.membership.states.Membership
-import net.corda.businessnetworks.membership.states.MembershipMetadata
+import net.corda.businessnetworks.membership.states.MembershipState
+import net.corda.businessnetworks.membership.states.SimpleMembershipMetadata
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
@@ -61,7 +61,7 @@ abstract class AbstractFlowTest(
         mockNetwork.stopNodes()
     }
 
-    fun runRequestMembershipFlow(nodeToRunTheFlow : StartedMockNode, membershipMetadata : MembershipMetadata = MembershipMetadata(role="DEFAULT")) : SignedTransaction {
+    fun runRequestMembershipFlow(nodeToRunTheFlow : StartedMockNode, membershipMetadata : SimpleMembershipMetadata = SimpleMembershipMetadata(role="DEFAULT")) : SignedTransaction {
         val future = nodeToRunTheFlow.startFlow(RequestMembershipFlow(membershipMetadata))
         mockNetwork.runNetwork()
         return future.getOrThrow()
@@ -93,21 +93,21 @@ abstract class AbstractFlowTest(
         return future.getOrThrow()
     }
 
-    fun runAmendMetadataFlow(nodeToRunTheFlow : StartedMockNode, newMetadata : MembershipMetadata) : SignedTransaction {
+    fun runAmendMetadataFlow(nodeToRunTheFlow : StartedMockNode, newMetadata : SimpleMembershipMetadata) : SignedTransaction {
         val future = nodeToRunTheFlow.startFlow(AmendMembershipMetadataFlow(newMetadata))
         mockNetwork.runNetwork()
         return future.getOrThrow()
     }
 
-    fun runGetMembershipsListFlow(nodeToRunTheFlow : StartedMockNode, force : Boolean, filterOutNotExisting : Boolean = true) : Map<Party, StateAndRef<Membership.State>> {
-        val future = nodeToRunTheFlow.startFlow(GetMembershipsFlow(force, filterOutNotExisting))
+    fun runGetMembershipsListFlow(nodeToRunTheFlow : StartedMockNode, force : Boolean, filterOutNotExisting : Boolean = true) : Map<Party, StateAndRef<MembershipState<SimpleMembershipMetadata>>> {
+        val future = nodeToRunTheFlow.startFlow(GetMembershipsFlow<SimpleMembershipMetadata>(force, filterOutNotExisting))
         mockNetwork.runNetwork()
         return future.getOrThrow()
     }
 
     fun getMembership (node : StartedMockNode, party : Party) = node.transaction {
             val dbService = node.services.cordaService(DatabaseService::class.java)
-            dbService.getMembership(party)!!
+            dbService.getMembership(party)!! as StateAndRef<MembershipState<SimpleMembershipMetadata>>
         }
 
     fun allTransactions(node : StartedMockNode) = node.transaction {

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/ActivateMembershipFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/ActivateMembershipFlowTest.kt
@@ -2,7 +2,7 @@ package net.corda.businessnetworks.membership
 
 import net.corda.businessnetworks.membership.bno.OnMembershipActivated
 import net.corda.businessnetworks.membership.bno.service.BNOConfigurationService
-import net.corda.businessnetworks.membership.states.Membership
+import net.corda.businessnetworks.membership.states.MembershipContract
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -45,8 +45,8 @@ class ActivateMembershipFlowTest : AbstractFlowTest(2) {
         val outputTxState = stx.tx.outputs.single()
         val command = stx.tx.commands.single()
 
-        assert(Membership.CONTRACT_NAME == outputTxState.contract)
-        assert(command.value is Membership.Commands.Activate)
+        assert(MembershipContract.CONTRACT_NAME == outputTxState.contract)
+        assert(command.value is MembershipContract.Commands.Activate)
         assert(stx.tx.inputs.single() == inputMembership.ref)
 
         val notification = TestNotifyMembersFlowResponder.NOTIFICATIONS.single()
@@ -70,8 +70,8 @@ class ActivateMembershipFlowTest : AbstractFlowTest(2) {
         val outputTxState = stx.tx.outputs.single()
         val command = stx.tx.commands.single()
 
-        assert(Membership.CONTRACT_NAME == outputTxState.contract)
-        assert(command.value is Membership.Commands.Activate)
+        assert(MembershipContract.CONTRACT_NAME == outputTxState.contract)
+        assert(command.value is MembershipContract.Commands.Activate)
         assert(stx.tx.inputs.single() == inputMembership.ref)
 
         val notification = TestNotifyMembersFlowResponder.NOTIFICATIONS.single()

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/ActivateMembershipFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/ActivateMembershipFlowTest.kt
@@ -94,23 +94,6 @@ class ActivateMembershipFlowTest : AbstractFlowTest(2) {
         }
     }
 
-
-    @Test
-    fun `no message should be sent if notifications are disabled`() {
-        val bnoConfiguration = bnoNode.services.cordaService(BNOConfigurationService::class.java)
-
-
-        bnoConfiguration.reloadPropertiesFromFile(fileFromClasspath("membership-service-notifications-disabled.conf"))
-
-        val memberNode = participantsNodes.first()
-        val memberParty = identity(memberNode)
-
-        runRequestMembershipFlow(memberNode)
-        runActivateMembershipFlow(bnoNode, memberParty)
-
-        assert(TestNotifyMembersFlowResponder.NOTIFICATIONS.isEmpty())
-    }
-
     @Test
     fun `membership can be auto activated`() {
         val bnoConfiguration = bnoNode.services.cordaService(BNOConfigurationService::class.java)

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/AmendMembershipMetadataFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/AmendMembershipMetadataFlowTest.kt
@@ -44,27 +44,6 @@ class AmendMembershipMetadataFlowTest : AbstractFlowTest(2) {
         assert(notifiedParty == memberParty)
     }
 
-
-    @Test
-    fun `no message should be sent if notifications are disabled`() {
-        assert(TestNotifyMembersFlowResponder.NOTIFICATIONS.isEmpty())
-        val bnoConfiguration = bnoNode.services.cordaService(BNOConfigurationService::class.java)
-        bnoConfiguration.reloadPropertiesFromFile(fileFromClasspath("membership-service-notifications-disabled.conf"))
-
-        val memberNode = participantsNodes.first()
-        val memberParty = identity(memberNode)
-
-        runRequestMembershipFlow(memberNode)
-        runActivateMembershipFlow(bnoNode, memberParty)
-
-        val existingMembership = getMembership(memberNode, memberParty)
-        val newMetadata = existingMembership.state.data.membershipMetadata.copy(role = "Some other role")
-
-        runAmendMetadataFlow(memberNode, newMetadata)
-
-        assert(TestNotifyMembersFlowResponder.NOTIFICATIONS.isEmpty())
-    }
-
     @Test
     fun `non members should be unable to trigger this flow`() {
         val memberNode = participantsNodes.first()

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/AmendMembershipMetadataFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/AmendMembershipMetadataFlowTest.kt
@@ -2,8 +2,9 @@ package net.corda.businessnetworks.membership
 
 import net.corda.businessnetworks.membership.bno.OnMembershipChanged
 import net.corda.businessnetworks.membership.bno.service.BNOConfigurationService
-import net.corda.businessnetworks.membership.states.Membership
-import net.corda.businessnetworks.membership.states.MembershipMetadata
+import net.corda.businessnetworks.membership.states.MembershipContract
+import net.corda.businessnetworks.membership.states.MembershipState
+import net.corda.businessnetworks.membership.states.SimpleMembershipMetadata
 import net.corda.core.flows.FlowException
 import org.junit.Test
 
@@ -31,11 +32,11 @@ class AmendMembershipMetadataFlowTest : AbstractFlowTest(2) {
         allSignedTx.verifyRequiredSignatures()
 
         val outputWithContract = allSignedTx.tx.outputs.single()
-        val outputMembership = outputWithContract.data as Membership.State
+        val outputMembership = outputWithContract.data as MembershipState<*>
         val command = allSignedTx.tx.commands.single()
 
-        assert(command.value is Membership.Commands.Amend)
-        assert(outputWithContract.contract == Membership.CONTRACT_NAME)
+        assert(command.value is MembershipContract.Commands.Amend)
+        assert(outputWithContract.contract == MembershipContract.CONTRACT_NAME)
         assert(outputMembership.membershipMetadata == newMetadata)
         assert(allSignedTx.inputs.single() == existingMembership.ref)
 
@@ -73,7 +74,7 @@ class AmendMembershipMetadataFlowTest : AbstractFlowTest(2) {
         runActivateMembershipFlow(bnoNode, memberParty)
 
         try {
-            runAmendMetadataFlow(memberNode, MembershipMetadata(role="Some role"))
+            runAmendMetadataFlow(memberNode, SimpleMembershipMetadata(role="Some role"))
         } catch (e : FlowException) {
             assert("$memberParty is not a member" == e.message)
         }

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/FullBNMSFlowDemo.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/FullBNMSFlowDemo.kt
@@ -2,7 +2,7 @@ package net.corda.businessnetworks.membership
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.businessnetworks.membership.member.GetMembershipsFlow
-import net.corda.businessnetworks.membership.states.MembershipMetadata
+import net.corda.businessnetworks.membership.states.SimpleMembershipMetadata
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
@@ -29,7 +29,7 @@ class FullBNMSFlowDemo : AbstractFlowTest(5) {
         val nonMember = participantsNodes[1]
 
         // participant submits a membership request to the BNO via RequestMembershipFlow
-        runRequestMembershipFlow(newJoiner, MembershipMetadata(role="My new role"))
+        runRequestMembershipFlow(newJoiner, SimpleMembershipMetadata(role="My new role"))
 
         // the flow issues MembershipState in PENDING status onto the ledger
         // After the state has been issued, the BNO needs to kick-off their internal KYC / on-boarding procedures, do all the paperwork and etc.
@@ -54,7 +54,7 @@ class FullBNMSFlowDemo : AbstractFlowTest(5) {
         }
 
         // Business Network members can amend their membership metadata via AmendMembershipMetadataFlow
-        runAmendMetadataFlow(newJoiner, MembershipMetadata(role="Some other role"))
+        runAmendMetadataFlow(newJoiner, SimpleMembershipMetadata(role="Some other role"))
 
         // BNO can revoke memberships via RevokeMembershipFlow
         runRevokeMembershipFlow(bnoNode, identity(newJoiner))
@@ -93,7 +93,7 @@ class FullBNMSFlowDemo : AbstractFlowTest(5) {
     class MyInitiatedFlow(val flowSession : FlowSession) : FlowLogic<Unit>() {
         @Suspendable
         override fun call() {
-            val memberships = subFlow(GetMembershipsFlow())
+            val memberships = subFlow(GetMembershipsFlow<SimpleMembershipMetadata>())
             if (!memberships.containsKey(flowSession.counterparty)) {
                 throw FlowException("Counterparty is not a member")
             }

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/FullBNMSFlowDemo.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/FullBNMSFlowDemo.kt
@@ -12,6 +12,7 @@ import net.corda.core.identity.Party
 import net.corda.core.utilities.getOrThrow
 import org.junit.Test
 import kotlin.test.fail
+import net.corda.businessnetworks.membership.member.Utils.ofType
 
 /**
  * This is a demo of the Business Network Membership Service. The test demonstrates how a participant can request to join a Business Network
@@ -41,7 +42,7 @@ class FullBNMSFlowDemo : AbstractFlowTest(5) {
         // otherwise the BNO will notify the existing members about the new-joiner immediately after membership activation
 
         // now the new-joiner can request memberships from the BNO via GetMembershipsFlow. Memberships list contains just a single party
-        val memberships = runGetMembershipsListFlow(newJoiner, false)
+        val memberships = runGetMembershipsListFlow(newJoiner, false).ofType<SimpleMembershipMetadata>()
         assert(memberships.keys.single() == identity(newJoiner))
         assert(memberships[identity(newJoiner)]!!.state.data.membershipMetadata.role == "My new role")
 
@@ -93,7 +94,7 @@ class FullBNMSFlowDemo : AbstractFlowTest(5) {
     class MyInitiatedFlow(val flowSession : FlowSession) : FlowLogic<Unit>() {
         @Suspendable
         override fun call() {
-            val memberships = subFlow(GetMembershipsFlow<SimpleMembershipMetadata>())
+            val memberships = subFlow(GetMembershipsFlow())
             if (!memberships.containsKey(flowSession.counterparty)) {
                 throw FlowException("Counterparty is not a member")
             }

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/FullBNMSFlowDemo.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/FullBNMSFlowDemo.kt
@@ -16,7 +16,7 @@ import net.corda.businessnetworks.membership.member.Utils.ofType
 
 /**
  * This is a demo of the Business Network Membership Service. The test demonstrates how a participant can request to join a Business Network
- * and then interact with other Business Network members. The test also demonstrates how the BNO can activate / revoke memberships
+ * and then interact with other Business Network members. The test also demonstrates how the BNO can activate / suspend memberships
  */
 class FullBNMSFlowDemo : AbstractFlowTest(5) {
     override fun registerFlows() {
@@ -57,10 +57,10 @@ class FullBNMSFlowDemo : AbstractFlowTest(5) {
         // Business Network members can amend their membership metadata via AmendMembershipMetadataFlow
         runAmendMetadataFlow(newJoiner, SimpleMembershipMetadata(role="Some other role"))
 
-        // BNO can revoke memberships via RevokeMembershipFlow
-        runRevokeMembershipFlow(bnoNode, identity(newJoiner))
+        // BNO can suspend memberships via SuspendMembershipFlow
+        runSuspendMembershipFlow(bnoNode, identity(newJoiner))
 
-        // revoked members are not able to transact on the Business Network neither can interact with the BNO's node
+        // suspended members are not able to transact on the Business Network neither can interact with the BNO's node
         try {
             runGetMembershipsListFlow(newJoiner, true)
             fail()
@@ -68,7 +68,7 @@ class FullBNMSFlowDemo : AbstractFlowTest(5) {
             // pass
         }
 
-        // BNO can re-activate revoked memberships via ActivateMembershipFlow
+        // BNO can re-activate suspended memberships via ActivateMembershipFlow
         runActivateMembershipFlow(bnoNode, identity(newJoiner))
 
         // Business Network members need to explicitly verify membership of their counterparties, before transacting with them

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/GetMembershipsFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/GetMembershipsFlowTest.kt
@@ -45,7 +45,7 @@ class GetMembershipsFlowTest : AbstractFlowTest(5) {
 
     @Test
     fun `only active members should be included`() {
-        val revokedNode = participantsNodes[0]
+        val suspendedNode = participantsNodes[0]
         val pendingNode = participantsNodes[1]
         val okNode = participantsNodes[2]
 
@@ -54,24 +54,24 @@ class GetMembershipsFlowTest : AbstractFlowTest(5) {
             if (it != pendingNode)
                 runActivateMembershipFlow(bnoNode, identity(it))
         }
-        runRevokeMembershipFlow(bnoNode, identity(revokedNode))
+        runSuspendMembershipFlow(bnoNode, identity(suspendedNode))
 
         val memberships = runGetMembershipsListFlow(okNode, true)
 
 
         assert(memberships.size == numberOfIdentities - 2)
-        assert(memberships.map { it.value.state.data.member }.toSet().none { it == identity(revokedNode) || it == identity(pendingNode) })
+        assert(memberships.map { it.value.state.data.member }.toSet().none { it == identity(suspendedNode) || it == identity(pendingNode) })
     }
 
     @Test
     fun `only active members should be able to use this flow`() {
-        val revokedNode = participantsNodes[0]
+        val suspendedNode = participantsNodes[0]
         val pendingNode = participantsNodes[1]
         val notMember = participantsNodes[3]
 
-        runRequestMembershipFlow(revokedNode)
+        runRequestMembershipFlow(suspendedNode)
         runRequestMembershipFlow(pendingNode)
-        runRevokeMembershipFlow(bnoNode, identity(revokedNode))
+        runSuspendMembershipFlow(bnoNode, identity(suspendedNode))
 
         try {
             runGetMembershipsListFlow(notMember, true)
@@ -86,10 +86,10 @@ class GetMembershipsFlowTest : AbstractFlowTest(5) {
             assert("Counterparty's ${identity(pendingNode)} membership in this business network is not active" == e.message)
         }
         try {
-            runGetMembershipsListFlow(revokedNode, true)
+            runGetMembershipsListFlow(suspendedNode, true)
             fail()
         } catch (e : MembershipNotActiveException) {
-            assert("Counterparty's ${identity(revokedNode)} membership in this business network is not active" == e.message)
+            assert("Counterparty's ${identity(suspendedNode)} membership in this business network is not active" == e.message)
         }
     }
 

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/RequestMembershipFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/RequestMembershipFlowTest.kt
@@ -2,7 +2,8 @@ package net.corda.businessnetworks.membership
 
 import net.corda.businessnetworks.membership.bno.RequestMembershipFlowResponder
 import net.corda.businessnetworks.membership.bno.service.DatabaseService
-import net.corda.businessnetworks.membership.states.Membership
+import net.corda.businessnetworks.membership.states.MembershipContract
+import net.corda.businessnetworks.membership.states.MembershipState
 import net.corda.core.flows.FlowException
 import org.junit.Test
 import kotlin.test.fail
@@ -23,11 +24,11 @@ class RequestMembershipFlowTest : AbstractFlowTest(2) {
         assert(stx.notary!!.name == notaryName)
 
         val outputWithContract = stx.tx.outputs.single()
-        val outputMembership = outputWithContract.data as Membership.State
+        val outputMembership = outputWithContract.data as MembershipState<*>
         val command = stx.tx.commands.single()
 
-        assert(command.value is Membership.Commands.Request)
-        assert(outputWithContract.contract == Membership.CONTRACT_NAME)
+        assert(command.value is MembershipContract.Commands.Request)
+        assert(outputWithContract.contract == MembershipContract.CONTRACT_NAME)
         assert(outputMembership.bno == bnoParty)
         assert(outputMembership.member == memberParty)
 

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/RequestMembershipFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/RequestMembershipFlowTest.kt
@@ -86,4 +86,6 @@ class RequestMembershipFlowTest : AbstractFlowTest(2) {
     }
 }
 
-class DummyMembershipContract : Contract, MembershipContract()
+class DummyMembershipContract : Contract, MembershipContract() {
+    override fun contractName() = "net.corda.businessnetworks.membership.DummyMembershipContract"
+}

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/SuspendMembershipFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/SuspendMembershipFlowTest.kt
@@ -2,13 +2,13 @@ package net.corda.businessnetworks.membership
 
 import net.corda.businessnetworks.membership.bno.OnMembershipRevoked
 import net.corda.businessnetworks.membership.bno.service.BNOConfigurationService
-import net.corda.businessnetworks.membership.states.Membership
+import net.corda.businessnetworks.membership.states.MembershipContract
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
 
-class RevokeMembershipFlowTest : AbstractFlowTest(2) {
+class SuspendMembershipFlowTest : AbstractFlowTest(2) {
 
     override fun registerFlows() {
         participantsNodes.forEach {
@@ -40,8 +40,8 @@ class RevokeMembershipFlowTest : AbstractFlowTest(2) {
         val outputTxState = stx.tx.outputs.single()
         val command = stx.tx.commands.single()
 
-        assert(Membership.CONTRACT_NAME == outputTxState.contract)
-        assert(command.value is Membership.Commands.Revoke)
+        assert(MembershipContract.CONTRACT_NAME == outputTxState.contract)
+        assert(command.value is MembershipContract.Commands.Suspend)
         assert(stx.inputs.single() == inputMembership.ref)
 
         val notifiedParties = TestNotifyMembersFlowResponder.NOTIFICATIONS.filter { it.second is OnMembershipRevoked }.map { it.first }
@@ -65,8 +65,8 @@ class RevokeMembershipFlowTest : AbstractFlowTest(2) {
         val outputTxState = stx.tx.outputs.single()
         val command = stx.tx.commands.single()
 
-        assert(Membership.CONTRACT_NAME == outputTxState.contract)
-        assert(command.value is Membership.Commands.Revoke)
+        assert(MembershipContract.CONTRACT_NAME == outputTxState.contract)
+        assert(command.value is MembershipContract.Commands.Suspend)
         assert(stx.inputs.single() == inputMembership.ref)
 
         val notifiedParties = TestNotifyMembersFlowResponder.NOTIFICATIONS.filter { it.second is OnMembershipRevoked }.map { it.first }

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/customizations/DummyMembershipAutoAcceptor.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/customizations/DummyMembershipAutoAcceptor.kt
@@ -1,11 +1,11 @@
 package net.corda.businessnetworks.membership.customizations
 
 import net.corda.businessnetworks.membership.bno.extension.MembershipAutoAcceptor
-import net.corda.businessnetworks.membership.states.Membership
+import net.corda.businessnetworks.membership.states.MembershipState
 
 class DummyMembershipAutoAcceptor : MembershipAutoAcceptor {
 
-    override fun autoActivateThisMembership(membershipState: Membership.State): Boolean {
+    override fun autoActivateThisMembership(membershipState: MembershipState<Any>): Boolean {
         return true
     }
 

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/member/service/MembershipsCacheTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/member/service/MembershipsCacheTest.kt
@@ -2,8 +2,8 @@ package net.corda.businessnetworks.membership.member.service
 
 import net.corda.businessnetworks.membership.AbstractFlowTest
 import net.corda.businessnetworks.membership.member.MembershipsListResponse
-import net.corda.businessnetworks.membership.states.Membership
-import net.corda.businessnetworks.membership.states.MembershipMetadata
+import net.corda.businessnetworks.membership.states.MembershipState
+import net.corda.businessnetworks.membership.states.SimpleMembershipMetadata
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.node.services.queryBy
 import org.junit.Test
@@ -41,7 +41,7 @@ class MembershipsCacheTest : AbstractFlowTest(5) {
         val cache = MembershipsCache.from(MembershipsListResponse(memberships, Instant.now()))
         val node = participantsNodes.first()
         val party = identity(node)
-        runAmendMetadataFlow(node, MembershipMetadata(role="New metadata"))
+        runAmendMetadataFlow(node, SimpleMembershipMetadata(role="New metadata"))
 
         val newMembership = getMembership(node, party)
 
@@ -51,14 +51,14 @@ class MembershipsCacheTest : AbstractFlowTest(5) {
         assert(cache.membershipMap[party] == newMembership)
     }
 
-    private fun initialiseMemberships() : List<StateAndRef<Membership.State>> {
+    private fun initialiseMemberships() : List<StateAndRef<MembershipState<Any>>> {
         participantsNodes.forEach {
             runRequestMembershipFlow(it)
             runActivateMembershipFlow(bnoNode, identity(it))
         }
 
         return participantsNodes.map {
-            it.transaction { it.services.vaultService.queryBy<Membership.State>().states }.single()
+            it.transaction { it.services.vaultService.queryBy<MembershipState<Any>>().states }.single()
         }
     }
 }

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/member/service/MembershipsCacheTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/net/corda/businessnetworks/membership/member/service/MembershipsCacheTest.kt
@@ -18,19 +18,18 @@ class MembershipsCacheTest : AbstractFlowTest(5) {
         val memberships = initialiseMemberships()
         val cache = MembershipsCache.from(MembershipsListResponse(memberships))
 
-        assert(cache.expires == null)
         assert(cache.membershipMap.map { it.value }.toSet() == memberships.toSet())
         memberships.forEach { assert(it == cache.membershipMap[it.state.data.member]) }
     }
 
     @Test
-    fun `test revoke membership`() {
+    fun `test suspend membership`() {
         val memberships = initialiseMemberships()
-        val cache = MembershipsCache.from(MembershipsListResponse(memberships, Instant.now()))
+        val cache = MembershipsCache.from(MembershipsListResponse(memberships))
 
         val nodeToRevoke = participantsNodes.first()
         val partyToRevoke = identity(nodeToRevoke)
-        cache.revokeMembership(partyToRevoke)
+        cache.suspendMembership(partyToRevoke)
 
         assertFalse(cache.membershipMap.containsKey(partyToRevoke))
     }
@@ -38,7 +37,7 @@ class MembershipsCacheTest : AbstractFlowTest(5) {
     @Test
     fun `test update membership`() {
         val memberships = initialiseMemberships()
-        val cache = MembershipsCache.from(MembershipsListResponse(memberships, Instant.now()))
+        val cache = MembershipsCache.from(MembershipsListResponse(memberships))
         val node = participantsNodes.first()
         val party = identity(node)
         runAmendMetadataFlow(node, SimpleMembershipMetadata(role="New metadata"))

--- a/bn-apps/memberships-management/membership-service/src/test/resources/membership-service-fake-bno.conf
+++ b/bn-apps/memberships-management/membership-service/src/test/resources/membership-service-fake-bno.conf
@@ -1,3 +1,2 @@
 bnoName = "O=Participant 1,L=New York,C=US"
 notaryName = "O=Notary,L=London,C=GB"
-notificationsEnabled = true

--- a/bn-apps/memberships-management/membership-service/src/test/resources/membership-service-notifications-disabled.conf
+++ b/bn-apps/memberships-management/membership-service/src/test/resources/membership-service-notifications-disabled.conf
@@ -1,3 +1,0 @@
-bnoName = "O=BNO,L=New York,C=US"
-notaryName = "O=Notary,L=London,C=GB"
-notificationsEnabled = false

--- a/bn-apps/memberships-management/membership-service/src/test/resources/membership-service-with-auto-approver.conf
+++ b/bn-apps/memberships-management/membership-service/src/test/resources/membership-service-with-auto-approver.conf
@@ -1,4 +1,3 @@
 bnoName = "O=BNO,L=New York,C=US"
 notaryName = "O=Notary,L=London,C=GB"
-notificationsEnabled = true
 membershipAutoAcceptor = "net.corda.businessnetworks.membership.customizations.DummyMembershipAutoAcceptor"

--- a/bn-apps/memberships-management/membership-service/src/test/resources/membership-service-with-custom-contract.conf
+++ b/bn-apps/memberships-management/membership-service/src/test/resources/membership-service-with-custom-contract.conf
@@ -1,0 +1,3 @@
+bnoName = "O=BNO,L=New York,C=US"
+notaryName = "O=Notary,L=London,C=GB"
+membershipContractName = "net.corda.businessnetworks.membership.DummyMembershipContract"

--- a/bn-apps/memberships-management/membership-service/src/test/resources/membership-service.conf
+++ b/bn-apps/memberships-management/membership-service/src/test/resources/membership-service.conf
@@ -1,3 +1,2 @@
 bnoName = "O=BNO,L=New York,C=US"
 notaryName = "O=Notary,L=London,C=GB"
-notificationsEnabled = true


### PR DESCRIPTION
Changes:
1. Renamed `Revoke` to `Suspend` to better reflect the nature of this action
2. Removed periodic membership snapshot pulls (as they are useless). Now its push only.
3. Made `MembershipState` generic to allow users to provide their custom metadata as a generic parameter. This is the first step towards support for multiple business networks.
4. Added more javadocs. Refactored README file.  