### PR TITLE
Added API to check when artifacts have been sync for the last time

### DIFF
--- a/bn-apps/cordapp-updates-distribution/corda-updates-app/src/main/kotlin/net/corda/cordaupdates/app/member/GetLastSyncTimeFlow.kt
+++ b/bn-apps/cordapp-updates-distribution/corda-updates-app/src/main/kotlin/net/corda/cordaupdates/app/member/GetLastSyncTimeFlow.kt
@@ -1,0 +1,14 @@
+package net.corda.cordaupdates.app.member
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import java.time.Instant
+
+/**
+ * This flow return an Instant when the artifacts have been synced for the last time.
+ * Last sync time is not persisted through node restarts.
+ */
+class GetLastSyncTimeFlow : FlowLogic<Instant?>() {
+    @Suspendable
+    override fun call() = serviceHub.cordaService(SyncerService::class.java).lastSyncTime
+}

--- a/bn-apps/cordapp-updates-distribution/corda-updates-app/src/main/kotlin/net/corda/cordaupdates/app/member/SyncerService.kt
+++ b/bn-apps/cordapp-updates-distribution/corda-updates-app/src/main/kotlin/net/corda/cordaupdates/app/member/SyncerService.kt
@@ -7,6 +7,7 @@ import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
 import net.corda.core.serialization.SingletonSerializeAsToken
 import java.io.File
+import java.time.Instant
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 
@@ -31,6 +32,12 @@ class ArtifactsMetadataCache(private val appServiceHub : AppServiceHub) : Single
  */
 @CordaService
 internal class SyncerService(private val appServiceHub : AppServiceHub) : SingletonSerializeAsToken() {
+    // time when the artifacts have been synced
+    private var _lastSyncTime : Instant? = null
+
+    val lastSyncTime : Instant?
+        get() = _lastSyncTime
+
     companion object {
         val executor = Executors.newSingleThreadExecutor()!!
     }
@@ -64,7 +71,9 @@ internal class SyncerService(private val appServiceHub : AppServiceHub) : Single
      * Synchronously launches artifact synchronisation.
      */
     fun syncArtifacts(syncerConfiguration : SyncerConfiguration? = null) = refreshMetadataCacheSynchronously(syncerConfiguration) { syncer ->
-        syncer.syncCordapps()
+        val artifacts = syncer.syncCordapps()
+        _lastSyncTime = Instant.now()
+        artifacts
     }
 
     /**


### PR DESCRIPTION
This PR adds a flow to check when artifact synchronisation have been run for the last time. This is required to be able to check whether synchronisation is completed when using CDS from external systems (as synchronisation runs asynchronously). 

Last sync time is not persisted through node restarts.