### PR TITLE
Remove the dependency to membership-service from ledger-sync-service

### DIFF
--- a/bn-apps/ledger-sync/ledger-sync-service/build.gradle
+++ b/bn-apps/ledger-sync/ledger-sync-service/build.gradle
@@ -37,8 +37,6 @@ dependencies {
     cordaRuntime "$corda_release_group:corda:$corda_release_version"
 
     testCompile "$corda_release_group:corda-node-driver:$corda_release_version"
-
-    cordapp project(":bn-apps:memberships-management:membership-service")
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {

--- a/bn-apps/ledger-sync/ledger-sync-service/src/test/resources/membership-service.conf
+++ b/bn-apps/ledger-sync/ledger-sync-service/src/test/resources/membership-service.conf
@@ -1,4 +1,0 @@
-bnoName = "O=BNO,L=New York,C=US"
-notaryName = "O=Notary,L=London,C=GB"
-notificationsEnabled = true
-bnoWhitelist = ["O=BNO,L=New York,C=US"]


### PR DESCRIPTION
The ledger sync service does not actually require any of the membership service functionality.
It is outlined in the ledger flows how to to secure invocation of ledger sync requests using business network functionality.