### PR TITLE
Added category to Billing State

### DIFF
--- a/bn-apps/billing/README.md
+++ b/bn-apps/billing/README.md
@@ -16,7 +16,7 @@ Billing Service can be used for billing and metering on Business Networks. Billi
 ![Billing State Evolution](./resources/billing_state_evolution.png) 
 
 The billing / metering workflow consists of the following steps:
-1. The BNO issues a *BillingState* to each of their Business Network members. The BNO can either pre-allocate an amount that a member can spent (bounded state), or leave the amount empty which would effectively allow the member to spent an unlimited number of *Billing Chips* (unbounded state, can be used for transaction metering). *Billing States* might include an *expiry date*, after which the states can not be used anymore.  *Billing States* may also include a category which can be used to differentiate amongst multiple active billing states for a member.
+1. The BNO issues a *BillingState* to each of their Business Network members. The BNO can either pre-allocate an amount that a member can spent (bounded state), or leave the amount empty which would effectively allow the member to spent an unlimited number of *Billing Chips* (unbounded state, can be used for transaction metering). *Billing States* might include an *expiry date*, after which the states can not be used anymore.  *Billing States* may also include a externalId which can be used to differentiate amongst multiple active billing states for a member.
 2. A member unilaterally (the BNO's signature is not required) *chips offs* one or multiple *Billing Chips* from their *Billing State*. Chipping off increments the *spent* amount of the associated *Billing State*. 
 3. A member includes *Billing Chips* as inputs to a transaction he(she) needs to pay for. Paid-for transactions never contain *Billing States* as inputs and hence *Billing States* don't carry along any private transaction history. However, the valid *Billing States* must be included as *reference inputs* to prevent an expired, revoked or returned states from being used. Developers must define a logic in their contracts code that verifies that each of the required transaction participants had included enough of the Billing Chips as inputs.  
 4. In the end of the billing period the BNO requests each BN member to return their *Billing State*. In response to that, the members attach back all *unspent Billing Chips* to the respective *Billing States*, which decrements the *spent* amount value and then *return Billing States* to the BNO. The returned *Billing States* and the associated *Billing Chips* can not be used to pay for transactions anymore.  
@@ -61,7 +61,7 @@ class IssueBillingStateFlow(
     private val owner : Party, // a party to issue the BillingState to
     private val amount : Long, // the maximum amount of the Billing Chips that can be chipped off from this Billing State. Can be 0 for an unbounded spending.
     private val expiryDate : Instant? = null, // the Billing State's expiry date. All transactions that include Billing States with an expiry date defined must also contain a Time Window.
-    private val category : String? = null // a billing category to differentiate between multiple active billing states.  
+    private val externalId : String? = null // a billing externalId to differentiate between multiple active billing states.  
 )
 ```
 
@@ -87,7 +87,7 @@ class ChipOffBillingStateFlow(private val billingState : StateAndRef<BillingStat
 class MemberDatabaseService {
     fun getBillingStateByLinearId(linearId : UniqueIdentifier) : StateAndRef<BillingState>? 
     fun getOurActiveBillingStates() : List<StateAndRef<BillingState>> 
-    fun getOurActiveBillingStatesForCategory(category: String) : List<StateAndRef<BillingState>>
+    fun getOurActiveBillingStatesForExternalId(externalId: String) : List<StateAndRef<BillingState>>
     fun getOurActiveBillingStatesByIssuer(issuer : Party) : List<StateAndRef<BillingState>> 
     fun getBillingChipStatesByBillingStateLinearId(billingStateLinearId : UniqueIdentifier) : List<StateAndRef<BillingChipState>> 
     fun getBillingChipStateByLinearId(chipLinearId : UniqueIdentifier) : StateAndRef<BillingChipState>? 

--- a/bn-apps/billing/README.md
+++ b/bn-apps/billing/README.md
@@ -16,7 +16,7 @@ Billing Service can be used for billing and metering on Business Networks. Billi
 ![Billing State Evolution](./resources/billing_state_evolution.png) 
 
 The billing / metering workflow consists of the following steps:
-1. The BNO issues a *BillingState* to each of their Business Network members. The BNO can either pre-allocate an amount that a member can spent (bounded state), or leave the amount empty which would effectively allow the member to spent an unlimited number of *Billing Chips* (unbounded state, can be used for transaction metering). *Billing States* might include an *expiry date*, after which the states can not be used anymore.
+1. The BNO issues a *BillingState* to each of their Business Network members. The BNO can either pre-allocate an amount that a member can spent (bounded state), or leave the amount empty which would effectively allow the member to spent an unlimited number of *Billing Chips* (unbounded state, can be used for transaction metering). *Billing States* might include an *expiry date*, after which the states can not be used anymore.  *Billing States* may also include a category which can be used to differentiate amongst multiple active billing states for a member.
 2. A member unilaterally (the BNO's signature is not required) *chips offs* one or multiple *Billing Chips* from their *Billing State*. Chipping off increments the *spent* amount of the associated *Billing State*. 
 3. A member includes *Billing Chips* as inputs to a transaction he(she) needs to pay for. Paid-for transactions never contain *Billing States* as inputs and hence *Billing States* don't carry along any private transaction history. However, the valid *Billing States* must be included as *reference inputs* to prevent an expired, revoked or returned states from being used. Developers must define a logic in their contracts code that verifies that each of the required transaction participants had included enough of the Billing Chips as inputs.  
 4. In the end of the billing period the BNO requests each BN member to return their *Billing State*. In response to that, the members attach back all *unspent Billing Chips* to the respective *Billing States*, which decrements the *spent* amount value and then *return Billing States* to the BNO. The returned *Billing States* and the associated *Billing Chips* can not be used to pay for transactions anymore.  
@@ -60,7 +60,8 @@ A `BillingState` can be issued via `IssueBillingStateFlow`. The flow should be c
 class IssueBillingStateFlow(
     private val owner : Party, // a party to issue the BillingState to
     private val amount : Long, // the maximum amount of the Billing Chips that can be chipped off from this Billing State. Can be 0 for an unbounded spending.
-    private val expiryDate : Instant? = null // the Billing State's expiry date. All transactions that include Billing States with an expiry date defined must also contain a Time Window. 
+    private val expiryDate : Instant? = null, // the Billing State's expiry date. All transactions that include Billing States with an expiry date defined must also contain a Time Window.
+    private val category : String? = null // a billing category to differentiate between multiple active billing states.  
 )
 ```
 
@@ -86,6 +87,7 @@ class ChipOffBillingStateFlow(private val billingState : StateAndRef<BillingStat
 class MemberDatabaseService {
     fun getBillingStateByLinearId(linearId : UniqueIdentifier) : StateAndRef<BillingState>? 
     fun getOurActiveBillingStates() : List<StateAndRef<BillingState>> 
+    fun getOurActiveBillingStatesForCategory() : List<StateAndRef<BillingState>>
     fun getOurActiveBillingStatesByIssuer(issuer : Party) : List<StateAndRef<BillingState>> 
     fun getBillingChipStatesByBillingStateLinearId(billingStateLinearId : UniqueIdentifier) : List<StateAndRef<BillingChipState>> 
     fun getBillingChipStateByLinearId(chipLinearId : UniqueIdentifier) : StateAndRef<BillingChipState>? 

--- a/bn-apps/billing/README.md
+++ b/bn-apps/billing/README.md
@@ -87,7 +87,7 @@ class ChipOffBillingStateFlow(private val billingState : StateAndRef<BillingStat
 class MemberDatabaseService {
     fun getBillingStateByLinearId(linearId : UniqueIdentifier) : StateAndRef<BillingState>? 
     fun getOurActiveBillingStates() : List<StateAndRef<BillingState>> 
-    fun getOurActiveBillingStatesForCategory() : List<StateAndRef<BillingState>>
+    fun getOurActiveBillingStatesForCategory(category: String) : List<StateAndRef<BillingState>>
     fun getOurActiveBillingStatesByIssuer(issuer : Party) : List<StateAndRef<BillingState>> 
     fun getBillingChipStatesByBillingStateLinearId(billingStateLinearId : UniqueIdentifier) : List<StateAndRef<BillingChipState>> 
     fun getBillingChipStateByLinearId(chipLinearId : UniqueIdentifier) : StateAndRef<BillingChipState>? 

--- a/bn-apps/billing/billing-app/src/main/kotlin/com/r3/businessnetworks/billing/flows/bno/IssueBillingStateFlow.kt
+++ b/bn-apps/billing/billing-app/src/main/kotlin/com/r3/businessnetworks/billing/flows/bno/IssueBillingStateFlow.kt
@@ -25,7 +25,7 @@ import java.time.Instant
  * @param owner the party to issue the [BillingState] to
  * @param amount the maximum amount of the [BillingChipState]s that can be chipped off
  * @param expiryDate the expiry date of the [BillingState]. Can be null, in which case the [BillingState] will be unexpirable. Transactions that involve [BillingState]s with the expiry dates set must contain time windows.
- * @param category the billing category of the [BillingState].  This can be used to differentiate amongst multiple active billing states for a member.  Can be null
+ * @param category the billing externalId of the [BillingState].  This can be used to differentiate amongst multiple active billing states for a member.  Can be null
  * @returns issued [BillingState] with the [SignedTransaction]
  */
 @StartableByRPC

--- a/bn-apps/billing/billing-app/src/main/kotlin/com/r3/businessnetworks/billing/flows/bno/IssueBillingStateFlow.kt
+++ b/bn-apps/billing/billing-app/src/main/kotlin/com/r3/businessnetworks/billing/flows/bno/IssueBillingStateFlow.kt
@@ -7,6 +7,7 @@ import com.r3.businessnetworks.billing.flows.member.GetChipsByIssuer
 import com.r3.businessnetworks.billing.states.BillingContract
 import com.r3.businessnetworks.billing.states.BillingState
 import com.r3.businessnetworks.billing.states.BillingStateStatus
+import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.flows.CollectSignaturesFlow
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
@@ -24,20 +25,22 @@ import java.time.Instant
  * @param owner the party to issue the [BillingState] to
  * @param amount the maximum amount of the [BillingChipState]s that can be chipped off
  * @param expiryDate the expiry date of the [BillingState]. Can be null, in which case the [BillingState] will be unexpirable. Transactions that involve [BillingState]s with the expiry dates set must contain time windows.
+ * @param category the billing category of the [BillingState].  This can be used to differentiate amongst multiple active billing states for a member.  Can be null
  * @returns issued [BillingState] with the [SignedTransaction]
  */
 @StartableByRPC
 @InitiatingFlow
 class IssueBillingStateFlow(private val owner : Party,
                             private val amount : Long,
-                            private val expiryDate : Instant? = null) : FlowLogic<Pair<BillingState, SignedTransaction>>() {
+                            private val expiryDate : Instant? = null,
+                            private val category : String? = null) : FlowLogic<Pair<BillingState, SignedTransaction>>() {
 
     @Suspendable
     override fun call() : Pair<BillingState, SignedTransaction> {
         val configuration = serviceHub.cordaService(BNOConfigurationService::class.java)
         val notary = configuration.notaryParty()
 
-        val billingState = BillingState(ourIdentity, owner, amount, 0L, BillingStateStatus.ACTIVE, expiryDate)
+        val billingState = BillingState(ourIdentity, owner, amount, 0L, BillingStateStatus.ACTIVE, expiryDate, category)
         val builder = TransactionBuilder(notary)
                 .addOutputState(billingState, BillingContract.CONTRACT_NAME)
                 .addCommand(BillingContract.Commands.Issue(), ourIdentity.owningKey, owner.owningKey)

--- a/bn-apps/billing/billing-app/src/main/kotlin/com/r3/businessnetworks/billing/flows/member/service/MemberBillingDatabaseService.kt
+++ b/bn-apps/billing/billing-app/src/main/kotlin/com/r3/businessnetworks/billing/flows/member/service/MemberBillingDatabaseService.kt
@@ -31,10 +31,10 @@ class MemberBillingDatabaseService(private val appServiceHub : AppServiceHub) : 
                 .and(QueryCriteria.VaultCustomQueryCriteria(statusCriteria))).states
     }
 
-    fun getOurActiveBillingStatesForCategory(category: String) : List<StateAndRef<BillingState>> {
-        val ownerCriteria = BillingStateSchemaV2.PersistentBillingState::owner.equal(me)
-        val statusCriteria = BillingStateSchemaV2.PersistentBillingState::status.equal(BillingStateStatus.ACTIVE)
-        val categoryCriteria = BillingStateSchemaV2.PersistentBillingState::category.equal(category)
+    fun getOurActiveBillingStatesForExternalId(externalId: String) : List<StateAndRef<BillingState>> {
+        val ownerCriteria = BillingStateSchemaV1.PersistentBillingState::owner.equal(me)
+        val statusCriteria = BillingStateSchemaV1.PersistentBillingState::status.equal(BillingStateStatus.ACTIVE)
+        val categoryCriteria = BillingStateSchemaV1.PersistentBillingState::externalId.equal(externalId)
 
         return appServiceHub.vaultService.queryBy<BillingState>(QueryCriteria.VaultCustomQueryCriteria(ownerCriteria)
                 .and(QueryCriteria.VaultCustomQueryCriteria(statusCriteria))

--- a/bn-apps/billing/billing-app/src/main/kotlin/com/r3/businessnetworks/billing/flows/member/service/MemberBillingDatabaseService.kt
+++ b/bn-apps/billing/billing-app/src/main/kotlin/com/r3/businessnetworks/billing/flows/member/service/MemberBillingDatabaseService.kt
@@ -1,10 +1,6 @@
 package com.r3.businessnetworks.billing.flows.member.service
 
-import com.r3.businessnetworks.billing.states.BillingChipState
-import com.r3.businessnetworks.billing.states.BillingChipStateSchemaV1
-import com.r3.businessnetworks.billing.states.BillingState
-import com.r3.businessnetworks.billing.states.BillingStateSchemaV1
-import com.r3.businessnetworks.billing.states.BillingStateStatus
+import com.r3.businessnetworks.billing.states.*
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.Party
@@ -33,6 +29,16 @@ class MemberBillingDatabaseService(private val appServiceHub : AppServiceHub) : 
         val statusCriteria = BillingStateSchemaV1.PersistentBillingState::status.equal(BillingStateStatus.ACTIVE)
         return appServiceHub.vaultService.queryBy<BillingState>(QueryCriteria.VaultCustomQueryCriteria(ownerCriteria)
                 .and(QueryCriteria.VaultCustomQueryCriteria(statusCriteria))).states
+    }
+
+    fun getOurActiveBillingStatesForCategory(category: String) : List<StateAndRef<BillingState>> {
+        val ownerCriteria = BillingStateSchemaV2.PersistentBillingState::owner.equal(me)
+        val statusCriteria = BillingStateSchemaV2.PersistentBillingState::status.equal(BillingStateStatus.ACTIVE)
+        val categoryCriteria = BillingStateSchemaV2.PersistentBillingState::category.equal(category)
+
+        return appServiceHub.vaultService.queryBy<BillingState>(QueryCriteria.VaultCustomQueryCriteria(ownerCriteria)
+                .and(QueryCriteria.VaultCustomQueryCriteria(statusCriteria))
+                .and(QueryCriteria.VaultCustomQueryCriteria(categoryCriteria))).states
     }
 
     fun getOurActiveBillingStatesByIssuer(issuer : Party) : List<StateAndRef<BillingState>> {

--- a/bn-apps/billing/billing-app/src/test/kotlin/com/r3/businessnetworks/billing/flows/bno/IssueBillingStateFlowTest.kt
+++ b/bn-apps/billing/billing-app/src/test/kotlin/com/r3/businessnetworks/billing/flows/bno/IssueBillingStateFlowTest.kt
@@ -25,7 +25,6 @@ class IssueBillingStateFlowTest : AbstractBusinessNetworksFlowTest(
     fun `test issue`() {
         val amount = 100L
         val expiryDate = Instant.now()
-        val category = "Testing"
 
         runFlowAndReturn(bnoNode(), IssueBillingStateFlow(participantNode().identity(), amount, expiryDate))
 

--- a/bn-apps/billing/billing-app/src/test/kotlin/com/r3/businessnetworks/billing/flows/bno/IssueBillingStateFlowTest.kt
+++ b/bn-apps/billing/billing-app/src/test/kotlin/com/r3/businessnetworks/billing/flows/bno/IssueBillingStateFlowTest.kt
@@ -25,6 +25,7 @@ class IssueBillingStateFlowTest : AbstractBusinessNetworksFlowTest(
     fun `test issue`() {
         val amount = 100L
         val expiryDate = Instant.now()
+        val category = "Testing"
 
         runFlowAndReturn(bnoNode(), IssueBillingStateFlow(participantNode().identity(), amount, expiryDate))
 

--- a/bn-apps/billing/billing-contracts-and-states/src/main/kotlin/com/r3/businessnetworks/billing/states/BillingContract.kt
+++ b/bn-apps/billing/billing-contracts-and-states/src/main/kotlin/com/r3/businessnetworks/billing/states/BillingContract.kt
@@ -230,15 +230,17 @@ data class BillingState(
         val status : BillingStateStatus = BillingStateStatus.ACTIVE, // billing state status
         val expiryDate : Instant? = null, // billing state expiry date. If the expiry date is null then state is considered to be unexpirable.
                                           // Transactions involving expirable states require TimeWindow to be provided.
+        val category : String? = null, // an optional billing category to differentiate multiple active billing states
         override val linearId : UniqueIdentifier = UniqueIdentifier()
 ) : LinearState, QueryableState {
     override fun generateMappedObject(schema : MappedSchema) : PersistentState {
         return when (schema) {
             is BillingStateSchemaV1 -> BillingStateSchemaV1.PersistentBillingState(issuer, owner, status)
+            is BillingStateSchemaV2 -> BillingStateSchemaV2.PersistentBillingState(issuer, owner, status, category)
             else -> throw IllegalArgumentException("Unrecognised schema $schema")
         }
     }
-    override fun supportedSchemas() = listOf(BillingStateSchemaV1)
+    override fun supportedSchemas() = listOf(BillingStateSchemaV1, BillingStateSchemaV2)
 
     override val participants = listOf(owner, issuer)
 

--- a/bn-apps/billing/billing-contracts-and-states/src/main/kotlin/com/r3/businessnetworks/billing/states/BillingContract.kt
+++ b/bn-apps/billing/billing-contracts-and-states/src/main/kotlin/com/r3/businessnetworks/billing/states/BillingContract.kt
@@ -4,7 +4,6 @@ import net.corda.core.contracts.BelongsToContract
 import net.corda.core.contracts.Command
 import net.corda.core.contracts.CommandData
 import net.corda.core.contracts.Contract
-import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.LinearState
 import net.corda.core.contracts.TypeOnlyCommandData
 import net.corda.core.contracts.UniqueIdentifier
@@ -230,17 +229,16 @@ data class BillingState(
         val status : BillingStateStatus = BillingStateStatus.ACTIVE, // billing state status
         val expiryDate : Instant? = null, // billing state expiry date. If the expiry date is null then state is considered to be unexpirable.
                                           // Transactions involving expirable states require TimeWindow to be provided.
-        val category : String? = null, // an optional billing category to differentiate multiple active billing states
+        val externalId : String? = null, // an optional billing externalId to differentiate multiple active billing states
         override val linearId : UniqueIdentifier = UniqueIdentifier()
 ) : LinearState, QueryableState {
     override fun generateMappedObject(schema : MappedSchema) : PersistentState {
         return when (schema) {
-            is BillingStateSchemaV1 -> BillingStateSchemaV1.PersistentBillingState(issuer, owner, status)
-            is BillingStateSchemaV2 -> BillingStateSchemaV2.PersistentBillingState(issuer, owner, status, category)
+            is BillingStateSchemaV1 -> BillingStateSchemaV1.PersistentBillingState(issuer, owner, status, externalId)
             else -> throw IllegalArgumentException("Unrecognised schema $schema")
         }
     }
-    override fun supportedSchemas() = listOf(BillingStateSchemaV1, BillingStateSchemaV2)
+    override fun supportedSchemas() = listOf(BillingStateSchemaV1)
 
     override val participants = listOf(owner, issuer)
 

--- a/bn-apps/billing/billing-contracts-and-states/src/main/kotlin/com/r3/businessnetworks/billing/states/Schemas.kt
+++ b/bn-apps/billing/billing-contracts-and-states/src/main/kotlin/com/r3/businessnetworks/billing/states/Schemas.kt
@@ -22,6 +22,21 @@ object BillingStateSchemaV1 : MappedSchema(schemaFamily = BillingState::class.ja
 }
 
 @CordaSerializable
+object BillingStateSchemaV2 : MappedSchema(schemaFamily = BillingState::class.java, version = 2, mappedTypes = listOf(PersistentBillingState::class.java)) {
+    @Entity
+    @Table(name = "billing_states2")
+    class PersistentBillingState (
+            @Column(name = "issuer")
+            var issuer: Party,
+            @Column(name = "owner")
+            var owner : Party,
+            @Column(name = "status")
+            var status : BillingStateStatus,
+            @Column(name = "category", nullable = true)
+            var category : String?) : PersistentState()
+}
+
+@CordaSerializable
 object BillingChipStateSchemaV1 : MappedSchema(schemaFamily = BillingChipState::class.java, version = 1, mappedTypes = listOf(PersistentBillingChipState::class.java)) {
     @Entity
     @Table(name = "billing_chip_states")

--- a/bn-apps/billing/billing-contracts-and-states/src/main/kotlin/com/r3/businessnetworks/billing/states/Schemas.kt
+++ b/bn-apps/billing/billing-contracts-and-states/src/main/kotlin/com/r3/businessnetworks/billing/states/Schemas.kt
@@ -18,22 +18,11 @@ object BillingStateSchemaV1 : MappedSchema(schemaFamily = BillingState::class.ja
             @Column(name = "owner")
             var owner : Party,
             @Column(name = "status")
-            var status : BillingStateStatus) : PersistentState()
-}
-
-@CordaSerializable
-object BillingStateSchemaV2 : MappedSchema(schemaFamily = BillingState::class.java, version = 2, mappedTypes = listOf(PersistentBillingState::class.java)) {
-    @Entity
-    @Table(name = "billing_states2")
-    class PersistentBillingState (
-            @Column(name = "issuer")
-            var issuer: Party,
-            @Column(name = "owner")
-            var owner : Party,
-            @Column(name = "status")
             var status : BillingStateStatus,
-            @Column(name = "category", nullable = true)
-            var category : String?) : PersistentState()
+            @Column(name = "externalId", nullable = true)
+            var externalId : String?) : PersistentState()
+
+    override val migrationResource = "billing.changelog-master.xml"
 }
 
 @CordaSerializable

--- a/bn-apps/billing/billing-contracts-and-states/src/resources/billing.changelog-master.xml
+++ b/bn-apps/billing/billing-contracts-and-states/src/resources/billing.changelog-master.xml
@@ -1,0 +1,4 @@
+<databaseChangeLog>
+    <include file="migration/billing.changelog-init.xml"/>
+    <include file="migration/billing.changelog-v2.xml"/>
+</databaseChangeLog>

--- a/bn-apps/billing/billing-contracts-and-states/src/resources/migration/billing.changelog-init.xml
+++ b/bn-apps/billing/billing-contracts-and-states/src/resources/migration/billing.changelog-init.xml
@@ -1,0 +1,13 @@
+<changeSet author="R3 Corda" id="initial script for billing_states">
+    <createTable tableName="billing_states">
+        <column name="output_index" type="INT">
+            <constraints nullable="false"/>
+        </column>
+        <column name="transaction_id" type="NVARCHAR(64)">
+            <constraints nullable="false"/>
+        </column>
+        <column name="issuer" type="NVARCHAR(255)"/>
+        <column name="owner" type="NVARCHAR(255)"/>
+        <column name="status" type="INT"/>
+    </createTable>
+</changeSet>

--- a/bn-apps/billing/billing-contracts-and-states/src/resources/migration/billing.changelog-v2.xml
+++ b/bn-apps/billing/billing-contracts-and-states/src/resources/migration/billing.changelog-v2.xml
@@ -1,0 +1,5 @@
+<changeSet author="R3 Corda" id="add externalId to billing_states">
+    <addColumn tableName="billing_states">
+        <column name="externalId" type="nvarchar(255)"/>
+    </addColumn>
+</changeSet>

--- a/bn-apps/billing/billing-demo/src/main/kotlin/com/r3/businessnetworks/billing/demo/flows/Flows.kt
+++ b/bn-apps/billing/billing-demo/src/main/kotlin/com/r3/businessnetworks/billing/demo/flows/Flows.kt
@@ -121,7 +121,7 @@ class TransferSampleStateFlowResponder(val session : FlowSession) : FlowLogic<Un
 private fun chipOff(flowLogic : FlowLogic<*>) : Pair<StateAndRef<BillingState>, StateAndRef<BillingChipState>> {
     val databaseService = flowLogic.serviceHub.cordaService(MemberBillingDatabaseService::class.java)
     // getting billing state from the vault. We know that there is only one billing state in the vault for this example
-    // but in the case where multiple billing states have been issued, you could use the externalId on the
+    // but in the case where multiple billing states have been issued, you could use the category on the
     // billing state to filter out the one you require.
     val billingState = databaseService.getOurActiveBillingStates().single()
     // chipping off an amount for transaction

--- a/bn-apps/billing/billing-demo/src/main/kotlin/com/r3/businessnetworks/billing/demo/flows/Flows.kt
+++ b/bn-apps/billing/billing-demo/src/main/kotlin/com/r3/businessnetworks/billing/demo/flows/Flows.kt
@@ -120,7 +120,9 @@ class TransferSampleStateFlowResponder(val session : FlowSession) : FlowLogic<Un
 @Suspendable
 private fun chipOff(flowLogic : FlowLogic<*>) : Pair<StateAndRef<BillingState>, StateAndRef<BillingChipState>> {
     val databaseService = flowLogic.serviceHub.cordaService(MemberBillingDatabaseService::class.java)
-    // getting billing state from the vault. We know that there is only one billing state in the vault
+    // getting billing state from the vault. We know that there is only one billing state in the vault for this example
+    // but in the case where multiple billing states have been issued, you could use the externalId on the
+    // billing state to filter out the one you require.
     val billingState = databaseService.getOurActiveBillingStates().single()
     // chipping off an amount for transaction
     val (chips, _) = flowLogic.subFlow(ChipOffBillingStateFlow(billingState, SampleContract.BILLING_CHIPS_TO_PAY, 1))

--- a/bn-apps/billing/billing-demo/src/main/kotlin/com/r3/businessnetworks/billing/demo/flows/Flows.kt
+++ b/bn-apps/billing/billing-demo/src/main/kotlin/com/r3/businessnetworks/billing/demo/flows/Flows.kt
@@ -121,7 +121,7 @@ class TransferSampleStateFlowResponder(val session : FlowSession) : FlowLogic<Un
 private fun chipOff(flowLogic : FlowLogic<*>) : Pair<StateAndRef<BillingState>, StateAndRef<BillingChipState>> {
     val databaseService = flowLogic.serviceHub.cordaService(MemberBillingDatabaseService::class.java)
     // getting billing state from the vault. We know that there is only one billing state in the vault for this example
-    // but in the case where multiple billing states have been issued, you could use the category on the
+    // but in the case where multiple billing states have been issued, you could use the externalId on the
     // billing state to filter out the one you require.
     val billingState = databaseService.getOurActiveBillingStates().single()
     // chipping off an amount for transaction


### PR DESCRIPTION
I have added a category field to the BillingState so that we can differentiate multiple Billing States that may be issued to a member.

In my use case, I need to have two Billing States per member since all of the chips won't be treated of equal value.  One Billing State will be used in flows which chip off for counting transactions while the other billing state will be used in flows which issue chips based on a percentage of a settlement.  As I return these two separate billing metrics monthly from each member to the BNO I can then apply separate rates for each category type and don't have to treat all of the chips equal weight.

I considered naming it an externalId but I think that category is more appropriate; let me know what you think; I don't mind changing the field to "externalId" or "externalRef"