### PR TITLE
Fix `ConfigUtils` to load a classpath resource VS a file

### DIFF
--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/ConfigUtils.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/ConfigUtils.kt
@@ -15,9 +15,8 @@ object ConfigUtils {
         val defaultLocation = (Paths.get("cordapps").resolve("config").resolve(propertiesFileName)).toFile()
         return if (defaultLocation.exists()) ConfigFactory.parseFile(defaultLocation)
             else {
-            val url = this.javaClass.getResource("./$propertiesFileName") ?:
-                this.javaClass.getResource("/$propertiesFileName")
-                System.out.println("loadConfig URL: ${url}")
+                val url = this.javaClass.getResource("./$propertiesFileName")
+                    ?: this.javaClass.getResource("/$propertiesFileName")
                 ConfigFactory.parseURL(url)
         }
     }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/ConfigUtils.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/ConfigUtils.kt
@@ -3,6 +3,7 @@ package com.r3.businessnetworks.membership.flows
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import java.io.File
+import java.net.URL
 import java.nio.file.Paths
 
 /**
@@ -13,6 +14,11 @@ object ConfigUtils {
         val propertiesFileName = "membership-service.conf"
         val defaultLocation = (Paths.get("cordapps").resolve("config").resolve(propertiesFileName)).toFile()
         return if (defaultLocation.exists()) ConfigFactory.parseFile(defaultLocation)
-            else ConfigFactory.parseFile(File(ConfigUtils::class.java.classLoader.getResource(propertiesFileName).toURI()))
+            else {
+            val url = this.javaClass.getResource("./$propertiesFileName") ?:
+                this.javaClass.getResource("/$propertiesFileName")
+                System.out.println("loadConfig URL: ${url}")
+                ConfigFactory.parseURL(url)
+        }
     }
 }


### PR DESCRIPTION
I couldn't really make memberships-management pickup a config from the classpath when testing my app, so I fixed `ConfigUtils` to load a classpath resource VS an actual file when not using _nodeName/cordapps/config_. Also provided a "/membership-service.conf" fallback as "./membership-service.conf" might be confusing to users