### PR TITLE
Added a sensible error to be thrown when config is not found.

### DIFF
--- a/bn-apps/billing/billing-app/src/main/kotlin/com/r3/businessnetworks/billing/flows/bno/service/BNOConfigurationService.kt
+++ b/bn-apps/billing/billing-app/src/main/kotlin/com/r3/businessnetworks/billing/flows/bno/service/BNOConfigurationService.kt
@@ -2,7 +2,6 @@ package com.r3.businessnetworks.billing.flows.bno.service
 
 import com.r3.businessnetworks.utilities.AbstractConfigurationService
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.identity.Party
 import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
 
@@ -12,5 +11,4 @@ import net.corda.core.node.services.CordaService
 @CordaService
 class BNOConfigurationService(appServiceHub : AppServiceHub) : AbstractConfigurationService(appServiceHub, "billing-app") {
     override fun bnoName() : CordaX500Name  = throw NotImplementedError("This method should not be used")
-    override fun bnoParty() : Party = throw NotImplementedError("This method should not be used")
 }

--- a/bn-apps/billing/billing-app/src/main/kotlin/com/r3/businessnetworks/billing/flows/member/service/MemberConfigurationService.kt
+++ b/bn-apps/billing/billing-app/src/main/kotlin/com/r3/businessnetworks/billing/flows/member/service/MemberConfigurationService.kt
@@ -2,7 +2,6 @@ package com.r3.businessnetworks.billing.flows.member.service
 
 import com.r3.businessnetworks.utilities.AbstractConfigurationService
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.identity.Party
 import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
 
@@ -12,5 +11,4 @@ import net.corda.core.node.services.CordaService
 @CordaService
 class MemberConfigurationService(appServiceHub : AppServiceHub) : AbstractConfigurationService(appServiceHub, "billing-app") {
     override fun bnoName() : CordaX500Name  = throw NotImplementedError("This method should not be used")
-    override fun bnoParty() : Party = throw NotImplementedError("This method should not be used")
 }

--- a/bn-apps/businessnetworks-utilities/src/main/kotlin/com/r3/businessnetworks/utilities/AbstractConfigurationService.kt
+++ b/bn-apps/businessnetworks-utilities/src/main/kotlin/com/r3/businessnetworks/utilities/AbstractConfigurationService.kt
@@ -6,6 +6,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.node.AppServiceHub
 import net.corda.core.serialization.SingletonSerializeAsToken
+import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Paths
 
@@ -17,6 +18,7 @@ import java.nio.file.Paths
  */
 abstract class AbstractConfigurationService(val appServiceHub : AppServiceHub, val configName : String) : SingletonSerializeAsToken() {
     companion object {
+        private val logger = LoggerFactory.getLogger(AbstractConfigurationService::class.java)
         private const val BNO_NAME = "bnoName"
         private const val NOTARY_NAME = "notaryName"
     }
@@ -30,9 +32,9 @@ abstract class AbstractConfigurationService(val appServiceHub : AppServiceHub, v
         _config = ConfigFactory.parseFile(file)
     }
 
-    open fun bnoName() = CordaX500Name.parse(_config.getString(BNO_NAME))
+    open fun bnoName() = CordaX500Name.parse(_config.getStringOrThrow(BNO_NAME))
     open fun bnoParty() = getPartyOrThrowException(bnoName())
-    open fun notaryName() = CordaX500Name.parse(_config.getString(NOTARY_NAME))
+    open fun notaryName() = CordaX500Name.parse(_config.getStringOrThrow(NOTARY_NAME))
     open fun notaryParty() = getPartyOrThrowException(notaryName())
 
     fun getPartyOrThrowException(name : CordaX500Name) : Party {
@@ -45,10 +47,18 @@ abstract class AbstractConfigurationService(val appServiceHub : AppServiceHub, v
                 ?: throw IllegalArgumentException("Notary $name has not been found on the network")
     }
 
-    private fun loadConfig() : Config {
+    private fun loadConfig() : Config? {
         val fileName = "$configName.conf"
         val defaultLocation = (Paths.get("cordapps").resolve("config").resolve(fileName)).toFile()
         return if (defaultLocation.exists()) ConfigFactory.parseFile(defaultLocation)
-        else ConfigFactory.parseFile(File(AbstractConfigurationService::class.java.classLoader.getResource(fileName).toURI()))
+        else {
+            val configResource = AbstractConfigurationService::class.java.classLoader.getResource(fileName)
+            if (configResource == null) {
+                logger.error("Configuration $configName.conf has not bee found")
+                null
+            } else ConfigFactory.parseFile(File(configResource.toURI()))
+        }
     }
+
+    private fun Config?.getStringOrThrow(property : String) : String = _config?.getString(property) ?: throw IllegalArgumentException("Configuration $configName.conf has not bee found")
 }

--- a/bn-apps/businessnetworks-utilities/src/main/kotlin/com/r3/businessnetworks/utilities/AbstractConfigurationService.kt
+++ b/bn-apps/businessnetworks-utilities/src/main/kotlin/com/r3/businessnetworks/utilities/AbstractConfigurationService.kt
@@ -54,11 +54,11 @@ abstract class AbstractConfigurationService(val appServiceHub : AppServiceHub, v
         else {
             val configResource = AbstractConfigurationService::class.java.classLoader.getResource(fileName)
             if (configResource == null) {
-                logger.error("Configuration $configName.conf has not bee found")
+                logger.error("Configuration $configName.conf has not been found")
                 null
             } else ConfigFactory.parseFile(File(configResource.toURI()))
         }
     }
 
-    private fun Config?.getStringOrThrow(property : String) : String = _config?.getString(property) ?: throw IllegalArgumentException("Configuration $configName.conf has not bee found")
+    private fun Config?.getStringOrThrow(property : String) : String = _config?.getString(property) ?: throw IllegalArgumentException("Configuration $configName.conf has not been found")
 }

--- a/bn-apps/cordapp-updates-distribution/corda-updates-transport/build.gradle
+++ b/bn-apps/cordapp-updates-distribution/corda-updates-transport/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     compile("org.apache.maven:maven-resolver-provider:3.5.4") {
         exclude group: "org.apache.maven.resolver", module: "*"
     }
+    compile project(":bn-apps:businessnetworks-utilities")
     // corda dependencies
     cordaCompile "$corda_release_group:corda-core:$corda_release_version"
     cordaCompile "$corda_release_group:corda-node-api:$corda_release_version"

--- a/bn-apps/memberships-management/membership-service/build.gradle
+++ b/bn-apps/memberships-management/membership-service/build.gradle
@@ -40,8 +40,10 @@ dependencies {
     cordaCompile "$corda_release_group:corda-rpc:$corda_release_version"
     cordaCompile "$corda_release_group:corda-node-api:$corda_release_version"
     cordaRuntime "$corda_release_group:corda:$corda_release_version"
+    compile project(":bn-apps:businessnetworks-utilities")
     testCompile "$corda_release_group:corda-node-driver:$corda_release_version"
     testImplementation project(":bn-apps:memberships-management:test-utils")
+
 
     cordapp project(":bn-apps:memberships-management:membership-service-contracts-and-states")
 

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/service/BNOConfigurationService.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/service/BNOConfigurationService.kt
@@ -1,30 +1,15 @@
 package com.r3.businessnetworks.membership.flows.bno.service
 
-import com.r3.businessnetworks.membership.flows.ConfigUtils.loadConfig
-import com.typesafe.config.ConfigFactory
+import com.r3.businessnetworks.utilities.AbstractConfigurationService
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.node.ServiceHub
+import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
-import net.corda.core.serialization.SingletonSerializeAsToken
-import java.io.File
 
 /**
  * Configuration that is used by BNO app. The configuration is red from cordapps/config/membership-service.conf with a fallback to
  * membership-service.conf on the classpath.
  */
 @CordaService
-class BNOConfigurationService(private val serviceHub : ServiceHub) : SingletonSerializeAsToken() {
-    companion object {
-        const val NOTARY_NAME = "notaryName"
-    }
-
-    private var _config = loadConfig()
-
-    private fun notaryName() : CordaX500Name = CordaX500Name.parse(_config.getString(NOTARY_NAME))
-    fun notaryParty() = serviceHub.networkMapCache.getNotary(notaryName())
-            ?: throw IllegalArgumentException("Notary ${notaryName()} has not been found on the network")
-
-    fun reloadConfigurationFromFile(file : File) {
-        _config = ConfigFactory.parseFile(file)
-    }
+class BNOConfigurationService(private val serviceHub : AppServiceHub) : AbstractConfigurationService(serviceHub, "membership-service") {
+    override fun bnoName() : CordaX500Name  = throw NotImplementedError("This method should not be used")
 }

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/member/service/MemberConfigurationService.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/member/service/MemberConfigurationService.kt
@@ -1,34 +1,32 @@
 package com.r3.businessnetworks.membership.flows.member.service
 
-import com.typesafe.config.ConfigFactory
-import com.r3.businessnetworks.membership.flows.ConfigUtils.loadConfig
-import com.r3.businessnetworks.membership.states.MembershipContract
+import com.r3.businessnetworks.utilities.AbstractConfigurationService
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
-import net.corda.core.node.ServiceHub
+import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
-import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.loggerFor
-import java.io.File
 
 /**
  * Configuration that is used by member app.
  */
 @CordaService
-class MemberConfigurationService(private val serviceHub : ServiceHub) : SingletonSerializeAsToken() {
+class MemberConfigurationService(private val serviceHub : AppServiceHub) : AbstractConfigurationService(serviceHub, "membership-service") {
     companion object {
         // X500 name of the BNO
         const val BNO_WHITELIST = "bnoWhitelist"
         val logger = loggerFor<MemberConfigurationService>()
     }
 
-    private var _config = loadConfig()
+    override fun bnoName() : CordaX500Name  = throw NotImplementedError("This method should not be used")
+    override fun notaryName() = throw NotImplementedError("This method should not be used")
 
     /**
      * BNOs should be explicitly whitelisted. Any attempt to communicate with not whitelisted BNO would fail.
      */
     fun bnoIdentities() : Set<Party> {
-        return (if (_config.hasPath(BNO_WHITELIST)) _config.getStringList(BNO_WHITELIST) else listOf())
+        val config = _config ?: throw IllegalArgumentException("Configuration for membership service is missing")
+        return (if (config.hasPath(BNO_WHITELIST)) config.getStringList(BNO_WHITELIST) else listOf())
                 .asSequence().map {
                     val x500Name = CordaX500Name.parse(it)
                     val party = serviceHub.identityService.wellKnownPartyFromX500Name(x500Name)
@@ -37,9 +35,5 @@ class MemberConfigurationService(private val serviceHub : ServiceHub) : Singleto
                     }
                     party
                 }.filterNotNull().toSet()
-    }
-
-    fun reloadConfigurationFromFile(file : File) {
-        _config = ConfigFactory.parseFile(file)
     }
 }


### PR DESCRIPTION
1. Added a sensible error message when configuration is not found
2. Updated all configuration services to use the same abstract service, so this fix is propagated across all of the tools