### PR TITLE
Added fix for Meta Data using Java.lang classes and also added flow for Self Issuance of Membership by BNO

### DIFF
--- a/bn-apps/memberships-management/membership-service-contracts-and-states/src/main/kotlin/com/r3/businessnetworks/membership/states/Membership.kt
+++ b/bn-apps/memberships-management/membership-service-contracts-and-states/src/main/kotlin/com/r3/businessnetworks/membership/states/Membership.kt
@@ -133,9 +133,6 @@ data class MembershipState<out T : Any>(val member : Party,
     fun isActive() = status == MembershipStatus.ACTIVE
 }
 
-@CordaSerializable
-data class BasicMembershipMetaData(val data: String)
-
 /**
  * Statuses that a membership can go through.
  *

--- a/bn-apps/memberships-management/membership-service-contracts-and-states/src/main/kotlin/com/r3/businessnetworks/membership/states/Membership.kt
+++ b/bn-apps/memberships-management/membership-service-contracts-and-states/src/main/kotlin/com/r3/businessnetworks/membership/states/Membership.kt
@@ -133,6 +133,9 @@ data class MembershipState<out T : Any>(val member : Party,
     fun isActive() = status == MembershipStatus.ACTIVE
 }
 
+@CordaSerializable
+data class BasicMembershipMetaData(val data: String)
+
 /**
  * Statuses that a membership can go through.
  *

--- a/bn-apps/memberships-management/membership-service-contracts-and-states/src/test/kotlin/com/r3/businessnetworks/membership/states/MembershipContractTest.kt
+++ b/bn-apps/memberships-management/membership-service-contracts-and-states/src/test/kotlin/com/r3/businessnetworks/membership/states/MembershipContractTest.kt
@@ -184,10 +184,17 @@ class MembershipContractTest {
             }
             transaction {
                 val input = membershipState(MembershipStatus.SUSPENDED)
-                input(MembershipContract.CONTRACT_NAME,  input)
-                output(MembershipContract.CONTRACT_NAME,  input.copy(status = MembershipStatus.ACTIVE, modified = input.modified.plusMillis(1), membershipMetadata = SimpleMembershipMetadata(role = "Another metadata")))
+                input(MembershipContract.CONTRACT_NAME, input)
+                output(MembershipContract.CONTRACT_NAME, input.copy(status = MembershipStatus.ACTIVE, modified = input.modified.plusMillis(1), membershipMetadata = SimpleMembershipMetadata(role = "Another metadata")))
                 command(listOf(bno.publicKey), MembershipContract.Commands.Activate())
                 this.`fails with`("Input and output states of a membership activation transaction should have the same metadata")
+            }
+            transaction {
+                val input = membershipState(MembershipStatus.SUSPENDED)
+                input(MembershipContract.CONTRACT_NAME,  input)
+                output(MembershipContract.CONTRACT_NAME,  input.copy(status = MembershipStatus.ACTIVE, modified = input.modified.plusMillis(1), membershipMetadata = SimpleMembershipMetadata(role = "test")))
+                command(listOf(bno.publicKey), MembershipContract.Commands.Activate())
+                this.verifies()
             }
         }
     }

--- a/bn-apps/memberships-management/membership-service-contracts-and-states/src/test/kotlin/com/r3/businessnetworks/membership/states/MembershipContractTest.kt
+++ b/bn-apps/memberships-management/membership-service-contracts-and-states/src/test/kotlin/com/r3/businessnetworks/membership/states/MembershipContractTest.kt
@@ -156,18 +156,21 @@ class MembershipContractTest {
         ledgerServices.ledger {
             transaction {
                 output(MembershipContract.CONTRACT_NAME,  membershipState(member = bnoParty, status = MembershipStatus.ACTIVE))
-                command(listOf(bno.publicKey), MembershipContract.Commands.SelfIssue())
+                command(listOf(bno.publicKey), MembershipContract.Commands.Request())
+                command(listOf(bno.publicKey), MembershipContract.Commands.Activate())
                 this.verifies()
             }
             transaction {
                 output(MembershipContract.CONTRACT_NAME,  membershipState(member = bnoParty, status = MembershipStatus.PENDING))
-                command(listOf(bno.publicKey), MembershipContract.Commands.SelfIssue())
+                command(listOf(bno.publicKey), MembershipContract.Commands.Request())
+                command(listOf(bno.publicKey), MembershipContract.Commands.Activate())
                 this.fails()
             }
             transaction {
                 input(MembershipContract.CONTRACT_NAME, membershipState())
-                output(MembershipContract.CONTRACT_NAME,  membershipState(member = bnoParty, status = MembershipStatus.PENDING))
-                command(listOf(bno.publicKey), MembershipContract.Commands.SelfIssue())
+                output(MembershipContract.CONTRACT_NAME,  membershipState(member = memberParty, status = MembershipStatus.PENDING))
+                command(listOf(bno.publicKey), MembershipContract.Commands.Request())
+                command(listOf(bno.publicKey), MembershipContract.Commands.Activate())
                 this.fails()
             }
         }

--- a/bn-apps/memberships-management/membership-service-contracts-and-states/src/test/kotlin/com/r3/businessnetworks/membership/states/MembershipContractTest.kt
+++ b/bn-apps/memberships-management/membership-service-contracts-and-states/src/test/kotlin/com/r3/businessnetworks/membership/states/MembershipContractTest.kt
@@ -152,6 +152,28 @@ class MembershipContractTest {
     }
 
     @Test
+    fun `test self issue`() {
+        ledgerServices.ledger {
+            transaction {
+                output(MembershipContract.CONTRACT_NAME,  membershipState(member = bnoParty, status = MembershipStatus.ACTIVE))
+                command(listOf(bno.publicKey), MembershipContract.Commands.SelfIssue())
+                this.verifies()
+            }
+            transaction {
+                output(MembershipContract.CONTRACT_NAME,  membershipState(member = bnoParty, status = MembershipStatus.PENDING))
+                command(listOf(bno.publicKey), MembershipContract.Commands.SelfIssue())
+                this.fails()
+            }
+            transaction {
+                input(MembershipContract.CONTRACT_NAME, membershipState())
+                output(MembershipContract.CONTRACT_NAME,  membershipState(member = bnoParty, status = MembershipStatus.PENDING))
+                command(listOf(bno.publicKey), MembershipContract.Commands.SelfIssue())
+                this.fails()
+            }
+        }
+    }
+
+    @Test
     fun `test activate membership`() {
         ledgerServices.ledger {
             transaction {

--- a/bn-apps/memberships-management/membership-service-contracts-and-states/src/test/kotlin/com/r3/businessnetworks/membership/states/MembershipContractTest.kt
+++ b/bn-apps/memberships-management/membership-service-contracts-and-states/src/test/kotlin/com/r3/businessnetworks/membership/states/MembershipContractTest.kt
@@ -152,31 +152,6 @@ class MembershipContractTest {
     }
 
     @Test
-    fun `test self issue`() {
-        ledgerServices.ledger {
-            transaction {
-                output(MembershipContract.CONTRACT_NAME,  membershipState(member = bnoParty, status = MembershipStatus.ACTIVE))
-                command(listOf(bno.publicKey), MembershipContract.Commands.Request())
-                command(listOf(bno.publicKey), MembershipContract.Commands.Activate())
-                this.verifies()
-            }
-            transaction {
-                output(MembershipContract.CONTRACT_NAME,  membershipState(member = bnoParty, status = MembershipStatus.PENDING))
-                command(listOf(bno.publicKey), MembershipContract.Commands.Request())
-                command(listOf(bno.publicKey), MembershipContract.Commands.Activate())
-                this.fails()
-            }
-            transaction {
-                input(MembershipContract.CONTRACT_NAME, membershipState())
-                output(MembershipContract.CONTRACT_NAME,  membershipState(member = memberParty, status = MembershipStatus.PENDING))
-                command(listOf(bno.publicKey), MembershipContract.Commands.Request())
-                command(listOf(bno.publicKey), MembershipContract.Commands.Activate())
-                this.fails()
-            }
-        }
-    }
-
-    @Test
     fun `test activate membership`() {
         ledgerServices.ledger {
             transaction {

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/GenericsUtils.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/GenericsUtils.kt
@@ -16,7 +16,7 @@ fun MembershipState<Any>.getAttachmentIdForGenericParam(): SecureHash {
 }
 
 fun StateAndRef<MembershipState<Any>>.isAttachmentRequired(): Boolean {
-    return this.isAttachmentRequired()
+    return this.state.data.isAttachmentRequired()
 }
 
 fun MembershipState<Any>.isAttachmentRequired(): Boolean {

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/GenericsUtils.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/GenericsUtils.kt
@@ -14,3 +14,13 @@ fun MembershipState<Any>.getAttachmentIdForGenericParam(): SecureHash {
     val bytesOfCordapp = this.membershipMetadata.javaClass.location.readBytes()
     return bytesOfCordapp.sha256()
 }
+
+fun StateAndRef<MembershipState<Any>>.isAttachmentRequired(): Boolean {
+    return this.isAttachmentRequired()
+}
+
+fun MembershipState<Any>.isAttachmentRequired(): Boolean {
+    return this.membershipMetadata.javaClass.protectionDomain.codeSource != null
+}
+
+

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/ActivateMembershipFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/ActivateMembershipFlow.kt
@@ -5,6 +5,7 @@ import com.r3.businessnetworks.membership.flows.bno.service.BNOConfigurationServ
 import com.r3.businessnetworks.membership.flows.bno.service.DatabaseService
 import com.r3.businessnetworks.membership.flows.bno.support.BusinessNetworkOperatorFlowLogic
 import com.r3.businessnetworks.membership.flows.getAttachmentIdForGenericParam
+import com.r3.businessnetworks.membership.flows.isAttachmentRequired
 import com.r3.businessnetworks.membership.states.MembershipContract
 import com.r3.businessnetworks.membership.states.MembershipState
 import com.r3.businessnetworks.membership.states.MembershipStatus
@@ -40,7 +41,9 @@ open class ActivateMembershipFlow(val membership: StateAndRef<MembershipState<An
             .addInputState(membership)
             .addOutputState(membership.state.data.copy(status = MembershipStatus.ACTIVE, modified = serviceHub.clock.instant()), MembershipContract.CONTRACT_NAME)
             .addCommand(MembershipContract.Commands.Activate(), ourIdentity.owningKey)
-            .addAttachment(membership.getAttachmentIdForGenericParam())
+
+        if (membership.isAttachmentRequired()) builder.addAttachment(membership.getAttachmentIdForGenericParam())
+
         builder.verify(serviceHub)
         val selfSignedTx = serviceHub.signInitialTransaction(builder)
 

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/AmendMembershipMetadataFlowResponder.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/AmendMembershipMetadataFlowResponder.kt
@@ -5,6 +5,7 @@ import com.r3.businessnetworks.membership.flows.bno.service.BNOConfigurationServ
 import com.r3.businessnetworks.membership.flows.bno.service.DatabaseService
 import com.r3.businessnetworks.membership.flows.bno.support.BusinessNetworkOperatorInitiatedFlow
 import com.r3.businessnetworks.membership.flows.getAttachmentIdForGenericParam
+import com.r3.businessnetworks.membership.flows.isAttachmentRequired
 import com.r3.businessnetworks.membership.flows.member.AmendMembershipMetadataFlow
 import com.r3.businessnetworks.membership.flows.member.AmendMembershipMetadataRequest
 import com.r3.businessnetworks.membership.states.MembershipContract
@@ -42,7 +43,9 @@ open class AmendMembershipMetadataFlowResponder(flowSession: FlowSession) : Busi
             .addInputState(counterpartyMembership)
             .addOutputState(newMembership, MembershipContract.CONTRACT_NAME)
             .addCommand(MembershipContract.Commands.Amend(), flowSession.counterparty.owningKey, ourIdentity.owningKey)
-            .addAttachment(counterpartyMembership.getAttachmentIdForGenericParam())
+
+        if (counterpartyMembership.isAttachmentRequired())
+            builder.addAttachment(counterpartyMembership.getAttachmentIdForGenericParam())
 
         verifyTransaction(builder)
 

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/RequestMembershipFlowResponder.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/RequestMembershipFlowResponder.kt
@@ -5,6 +5,7 @@ import com.r3.businessnetworks.membership.flows.bno.service.BNOConfigurationServ
 import com.r3.businessnetworks.membership.flows.bno.service.DatabaseService
 import com.r3.businessnetworks.membership.flows.bno.support.BusinessNetworkOperatorFlowLogic
 import com.r3.businessnetworks.membership.flows.getAttachmentIdForGenericParam
+import com.r3.businessnetworks.membership.flows.isAttachmentRequired
 import com.r3.businessnetworks.membership.flows.member.OnBoardingRequest
 import com.r3.businessnetworks.membership.flows.member.RequestMembershipFlow
 import com.r3.businessnetworks.membership.states.MembershipContract
@@ -58,7 +59,9 @@ open class RequestMembershipFlowResponder(val session: FlowSession) : BusinessNe
             val builder = TransactionBuilder(notary)
                 .addOutputState(membership, MembershipContract.CONTRACT_NAME)
                 .addCommand(MembershipContract.Commands.Request(), counterparty.owningKey, ourIdentity.owningKey)
-                .addAttachment(membership.getAttachmentIdForGenericParam())
+
+            if (membership.isAttachmentRequired())
+                builder.addAttachment(membership.getAttachmentIdForGenericParam())
 
             verifyTransaction(builder)
 

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/SelfIssueMembershipFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/SelfIssueMembershipFlow.kt
@@ -1,0 +1,49 @@
+package com.r3.businessnetworks.membership.flows.bno
+
+import com.r3.businessnetworks.membership.flows.bno.service.BNOConfigurationService
+import com.r3.businessnetworks.membership.flows.member.Utils.throwExceptionIfNotBNO
+import com.r3.businessnetworks.membership.states.MembershipContract
+import com.r3.businessnetworks.membership.states.MembershipState
+import com.r3.businessnetworks.membership.states.MembershipStatus
+import net.corda.core.contracts.Command
+import net.corda.core.flows.*
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.ProgressTracker
+
+/**
+ * Self Issue a Membership.  This can only be done by a BNO
+ */
+@StartableByRPC
+@InitiatingFlow(version = 2)
+open class SelfIssueMembershipFlow(val metaData : Any) : FlowLogic<SignedTransaction>() {
+    companion object {
+        object IssuingMembership : ProgressTracker.Step("Issuing Membership")
+
+        fun tracker() = ProgressTracker(
+                IssuingMembership
+        )
+    }
+
+    override val progressTracker = tracker()
+
+    override fun call(): SignedTransaction {
+        throwExceptionIfNotBNO(ourIdentity, serviceHub)
+        progressTracker.currentStep = IssuingMembership
+
+        val config = serviceHub.cordaService(BNOConfigurationService::class.java)
+        val notary = config.notaryParty()
+        val membershipState = MembershipState(this.ourIdentity, this.ourIdentity, metaData, status = MembershipStatus.ACTIVE)
+        val txCommand = Command(MembershipContract.Commands.SelfIssue(), ourIdentity.owningKey)
+
+        val txBuilder = TransactionBuilder(notary).withItems()
+                .addOutputState(membershipState, MembershipContract.CONTRACT_NAME)
+                .addCommand(txCommand)
+
+        txBuilder.verify(serviceHub)
+        val tx = serviceHub.signInitialTransaction(txBuilder)
+
+        return subFlow(FinalityFlow(tx, emptyList()))
+    }
+}
+

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/SuspendMembershipFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/SuspendMembershipFlow.kt
@@ -5,6 +5,7 @@ import com.r3.businessnetworks.membership.flows.bno.service.BNOConfigurationServ
 import com.r3.businessnetworks.membership.flows.bno.service.DatabaseService
 import com.r3.businessnetworks.membership.flows.bno.support.BusinessNetworkOperatorFlowLogic
 import com.r3.businessnetworks.membership.flows.getAttachmentIdForGenericParam
+import com.r3.businessnetworks.membership.flows.isAttachmentRequired
 import com.r3.businessnetworks.membership.states.MembershipContract
 import com.r3.businessnetworks.membership.states.MembershipState
 import com.r3.businessnetworks.membership.states.MembershipStatus
@@ -37,7 +38,9 @@ open class SuspendMembershipFlow(val membership: StateAndRef<MembershipState<Any
             .addInputState(membership)
             .addOutputState(membership.state.data.copy(status = MembershipStatus.SUSPENDED, modified = serviceHub.clock.instant()))
             .addCommand(MembershipContract.Commands.Suspend(), ourIdentity.owningKey)
-            .addAttachment(membership.getAttachmentIdForGenericParam())
+
+        if (membership.isAttachmentRequired()) builder.addAttachment(membership.getAttachmentIdForGenericParam())
+
         builder.verify(serviceHub)
         val selfSignedTx = serviceHub.signInitialTransaction(builder)
 

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/AbstractFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/AbstractFlowTest.kt
@@ -100,6 +100,12 @@ abstract class AbstractFlowTest(private val numberOfBusinessNetworks : Int,
         return future.getOrThrow()
     }
 
+    fun runSelfIssueMembershipFlow(bnoNode : StartedMockNode, membershipMetadata : Any = SimpleMembershipMetadata(role = "DEFAULT")) : SignedTransaction {
+        val future = bnoNode.startFlow(SelfIssueMembershipFlow(membershipMetadata))
+        mockNetwork.runNetwork()
+        return future.getOrThrow()
+    }
+
     fun runRequestMembershipFlow(bnoNode : StartedMockNode, participantNodes : List<StartedMockNode>, membershipMetadata : Any = SimpleMembershipMetadata(role = "DEFAULT")) : List<SignedTransaction> {
         return participantNodes.map { runRequestMembershipFlow(bnoNode, it, membershipMetadata) }
     }

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/RequestMembershipFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/RequestMembershipFlowTest.kt
@@ -55,7 +55,7 @@ class RequestMembershipFlowTest : AbstractFlowTest(numberOfBusinessNetworks = 2,
     }
 
     @Test
-    fun `membership request should fail if another membership request form the same member is already in progress`() {
+    fun `membership request should fail if another membership request from the same member is already in progress`() {
         val bnoNode = bnoNodes.first()
         val participantNode = participantsNodes.first()
         val databaseService = bnoNode.services.cordaService(DatabaseService::class.java)

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/SelfIssueMembershipFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/SelfIssueMembershipFlowTest.kt
@@ -1,0 +1,54 @@
+package com.r3.businessnetworks.membership.flows
+
+import com.r3.businessnetworks.membership.flows.bno.RequestMembershipFlowResponder
+import com.r3.businessnetworks.membership.flows.bno.service.DatabaseService
+import com.r3.businessnetworks.membership.flows.member.service.MemberConfigurationService
+import com.r3.businessnetworks.membership.states.MembershipContract
+import com.r3.businessnetworks.membership.states.MembershipState
+import com.r3.businessnetworks.membership.testextensions.RequestMembershipFlowResponderWithMetadataVerification
+import net.corda.core.flows.FlowException
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class SelfIssueMembershipFlowTest : AbstractFlowTest(numberOfBusinessNetworks = 2,
+        numberOfParticipants = 2,
+        participantRespondingFlows = listOf(RequestMembershipFlowResponder::class.java)) {
+
+    @Test
+    fun `self issue happy path`() {
+        val bnoNode = bnoNodes.first()
+
+        val stx = runSelfIssueMembershipFlow(bnoNode)
+        
+        assert(stx.notary!!.name == notaryName)
+
+        val outputWithContract = stx.tx.outputs.single()
+        val outputMembership = outputWithContract.data as MembershipState<*>
+        val command = stx.tx.commands.single()
+
+        assert(command.value is MembershipContract.Commands.Activate)
+        assert(outputWithContract.contract == MembershipContract.CONTRACT_NAME)
+        assert(outputMembership.bno == bnoNode.identity())
+        assert(outputMembership.member == bnoNode.identity())
+        stx.verifyRequiredSignatures()
+
+        // no notifications should be sent at this point
+        assertTrue(NotificationsCounterFlow.NOTIFICATIONS.isEmpty())
+    }
+
+    @Test
+    fun `self issue should fail if a membership state already exists`() {
+        val bnoNode = bnoNodes.first()
+
+        runSelfIssueMembershipFlow(bnoNode)
+
+        try {
+            runSelfIssueMembershipFlow(bnoNode)
+            fail()
+        } catch (e : FlowException) {
+            assert("Membership already exists" == e.message)
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes an issue where the membership meta data in the MembershipState couldn't be a Java system class like java.lang.String.  If you used a String for the meta data before this fix you would get a Null Pointer on the "this.membershipMetadata.javaClass.location" call in getAttachmentIdForGenericParam() function.

Also, added a flow for a BNO to self issue his own Membership