### PR TITLE
Override progressTracker in order to allow flow invocation from the C…

### DIFF
--- a/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/com/r3/businessnetworks/ledgersync/EvaluateLedgerConsistencyFlow.kt
+++ b/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/com/r3/businessnetworks/ledgersync/EvaluateLedgerConsistencyFlow.kt
@@ -8,6 +8,7 @@ import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
 
 /**
@@ -19,6 +20,8 @@ import net.corda.core.utilities.unwrap
 class EvaluateLedgerConsistencyFlow(
         private val members: List<Party>
 ) : FlowLogic<Map<Party, Boolean>>() {
+
+    override val progressTracker: ProgressTracker = ProgressTracker()
 
     @Suspendable
     override fun call(): Map<Party, Boolean> = (members - ourIdentity)

--- a/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/com/r3/businessnetworks/ledgersync/RequestLedgersSyncFlow.kt
+++ b/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/com/r3/businessnetworks/ledgersync/RequestLedgersSyncFlow.kt
@@ -9,6 +9,7 @@ import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
+import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
 
 /**
@@ -20,6 +21,8 @@ import net.corda.core.utilities.unwrap
 class RequestLedgersSyncFlow(
         private val members: List<Party>
 ) : FlowLogic<Map<Party, LedgerSyncFindings>>() {
+
+    override val progressTracker: ProgressTracker = ProgressTracker()
 
     @Suspendable
     override fun call(): Map<Party, LedgerSyncFindings> = (members - ourIdentity)

--- a/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/com/r3/businessnetworks/ledgersync/TransactionRecoveryFlow.kt
+++ b/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/com/r3/businessnetworks/ledgersync/TransactionRecoveryFlow.kt
@@ -11,6 +11,7 @@ import net.corda.core.flows.SendTransactionFlow
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.node.StatesToRecord.ALL_VISIBLE
+import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
 
 /**
@@ -21,6 +22,8 @@ import net.corda.core.utilities.unwrap
 class TransactionRecoveryFlow(
         private val report: Map<Party, LedgerSyncFindings>
 ) : FlowLogic<Unit>() {
+
+    override val progressTracker: ProgressTracker = ProgressTracker()
 
     @Suspendable
     override fun call() {


### PR DESCRIPTION
Override progressTracker in order to allow flow invocation from the Corda Shell.

This would allow Node Operators to run the flows of the ledger-sync-service regardless of how other CorDapps are implemented.