### PR TITLE
Patch for ledger-sync between a Party node and a Regulator node

### DIFF
--- a/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/com/r3/businessnetworks/ledgersync/LedgerSyncAndRecoveryByRegulatorFlow.kt
+++ b/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/com/r3/businessnetworks/ledgersync/LedgerSyncAndRecoveryByRegulatorFlow.kt
@@ -1,0 +1,42 @@
+package com.r3.businessnetworks.ledgersync
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.Party
+import net.corda.core.utilities.ProgressTracker
+import net.corda.core.utilities.contextLogger
+
+/**
+ * This flow is used to recovery a Party node transactions records from the ledger data of Regulator node. 
+ */
+@InitiatingFlow
+@StartableByRPC
+class LedgerSyncAndRecoveryByRegulatorFlow( private var regulators: List<Party>? ) : FlowLogic<Unit>() {
+
+    constructor() : this(regulators = null)
+
+    companion object {
+        object FIND_REGULATORS : ProgressTracker.Step("Retrieving list of regulators if not provided")
+        object RECOVER_FINDINGS : ProgressTracker.Step("Requesting ledger sync updates between party and regulator nodes who we are inconsistent with")
+        object RECOVER_TRANSACTIONS : ProgressTracker.Step("Recovering transactions for the party from the regulator based on received ledger sync updates")
+        fun tracker() = ProgressTracker(FIND_REGULATORS, RECOVER_FINDINGS, RECOVER_TRANSACTIONS)
+    }
+
+    override val progressTracker = tracker()
+    @Suspendable
+    override fun call() {
+        progressTracker.currentStep = FIND_REGULATORS
+        if (regulators == null)
+         //We recover the regulators list from the NetworkMap if not provided
+            regulators = this.serviceHub.networkMapCache.regulatorNodes.map { it.legalIdentities.first() }
+        logger.info("Regulators list: $regulators")
+
+        progressTracker.currentStep = RECOVER_FINDINGS
+        val partiesAndFindings = subFlow(RequestRegulatorLedgerSyncFlow(regulators!!))
+
+        progressTracker.currentStep = RECOVER_TRANSACTIONS
+        return subFlow(TransactionRecoveryFlow(partiesAndFindings))
+    }
+}

--- a/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/com/r3/businessnetworks/ledgersync/RequestRegulatorLedgerSyncFlow.kt
+++ b/bn-apps/ledger-sync/ledger-sync-service/src/main/kotlin/com/r3/businessnetworks/ledgersync/RequestRegulatorLedgerSyncFlow.kt
@@ -1,0 +1,75 @@
+package com.r3.businessnetworks.ledgersync
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.Party
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.utilities.ProgressTracker
+import net.corda.core.utilities.unwrap
+import net.corda.core.utilities.contextLogger
+
+
+/**
+ * This flow is designed only for getting the detailed report between a Party node and the Regulator node.
+ * Based on this result, the Party node can recover its lost transaction records by referencing the Regulator node
+ * in some further actions (such as notifying the BNO) or recover the transactions found from Regulator node's ledger.
+ */
+@InitiatingFlow
+@StartableByRPC
+class RequestRegulatorLedgerSyncFlow(
+        private val members: List<Party>
+) : FlowLogic<Map<Party, LedgerSyncFindings>>() {
+
+    override val progressTracker: ProgressTracker = ProgressTracker()
+
+    companion object {
+        private val logger = contextLogger()
+    }
+
+    @Suspendable
+    override fun call(): Map<Party, LedgerSyncFindings> = (members - ourIdentity)
+            .map { they ->
+                //val knownTransactionsIds = serviceHub.vaultService.withParticipants(ourIdentity, they)
+                val knownTransactionsIds = serviceHub.vaultService.withParticipants(ourIdentity)
+                logger.info("they in RequestRegulatorLedgerSyncFlow is: $they")
+                logger.info("ourIdentity in RequestRegulatorLedgerSyncFlow is: $ourIdentity")
+                logger.info("knownTransactionsIds is: $knownTransactionsIds")
+
+                val findings = initiateFlow(they).sendAndReceive<LedgerSyncFindings>(knownTransactionsIds).unwrap { it }
+                // an individual implementation might treat findings differently, i.e. report them to the BNO
+                they to findings
+            }.toMap()
+}
+
+@Suppress("unused")
+@InitiatedBy(RequestRegulatorLedgerSyncFlow::class)
+class RespondRegulatorLedgerSyncFlow(
+        private val otherSideSession: FlowSession
+) : FlowLogic<Unit>() {
+    /**
+     * Depending on the use case, users of this flow might introduce additional validation logic. This could mean
+     * making `RespondLedgerSyncFlow` implement `BusinessNetworkAwareInitiatedFlow`, i.e.:
+     *
+     *      class RespondLedgerSyncFlow(
+     *          private val otherSideSession: FlowSession
+     *      ) : BusinessNetworkAwareInitiatedFlow<Unit>(otherSideSession)
+     *
+     * Subsequently `onCounterpartyMembershipVerified` can be used.
+     */
+
+    @Suspendable
+    override fun call() {
+        val theirs = otherSideSession.receive<List<SecureHash>>().unwrap { it }
+        //val ours = serviceHub.vaultService.withParticipants(ourIdentity, otherSideSession.counterparty)
+        val ours = serviceHub.vaultService.withParticipants(otherSideSession.counterparty)
+        otherSideSession.send(LedgerSyncFindings(
+                ours - theirs,
+                theirs - ours
+        ))
+    }
+}


### PR DESCRIPTION
Add the flows to recovery a Party node by using the ledger-data in a Regulator node.