### PR TITLE
[PSA-5] circumvent the flow session for self issue of membership

### DIFF
--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/SelfIssueMembershipFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/SelfIssueMembershipFlow.kt
@@ -2,60 +2,111 @@ package com.r3.businessnetworks.membership.flows.bno
 
 import co.paralleluniverse.fibers.Suspendable
 import com.r3.businessnetworks.membership.flows.bno.service.BNOConfigurationService
-import com.r3.businessnetworks.membership.flows.bno.service.DatabaseService
-import com.r3.businessnetworks.membership.flows.getAttachmentIdForGenericParam
-import com.r3.businessnetworks.membership.flows.isAttachmentRequired
-import com.r3.businessnetworks.membership.flows.member.RequestMembershipFlow
+import com.r3.businessnetworks.membership.flows.bno.support.BusinessNetworkOperatorFlowLogic
 import com.r3.businessnetworks.membership.flows.member.Utils.throwExceptionIfNotBNO
 import com.r3.businessnetworks.membership.states.MembershipContract
 import com.r3.businessnetworks.membership.states.MembershipState
 import com.r3.businessnetworks.membership.states.MembershipStatus
-import net.corda.core.contracts.Command
-import net.corda.core.flows.*
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.flows.FinalityFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.Party
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
-import java.time.Instant
 
 /**
- * Self Issue a Membership.  This can only be done by a BNO
+ * Self Issue a Membership.  This can only be done by a BNO,
+ * @param bnoMembership bno membership state to be activated
  */
+@Suppress("UNUSED_VARIABLE")
 @StartableByRPC
 @InitiatingFlow(version = 2)
-open class SelfIssueMembershipFlow(val metaData : Any) : FlowLogic<SignedTransaction>() {
+open class SelfIssueMembershipFlow(val bnoMembership: StateAndRef<MembershipState<Any>>) : FlowLogic<SignedTransaction>() {
     companion object {
-        object RequestingMembership : ProgressTracker.Step("Requesting Membership")
+        object ActivatedMembership : ProgressTracker.Step("Membership Activated")
         object ActivatingMembership : ProgressTracker.Step("Activating Membership")
+        object AlreadyActvie : ProgressTracker.Step("Membership is already active")
 
         fun tracker() = ProgressTracker(
-                RequestingMembership,
-                ActivatingMembership
+                ActivatedMembership,
+                ActivatingMembership,
+                AlreadyActvie
         )
     }
 
     override val progressTracker = tracker()
 
     @Suspendable
-    override fun call() : SignedTransaction {
+
+    //The call function will build a transaction which will only
+    // modify the BNO status and then self sign the transaction
+    override fun call(): SignedTransaction {
+        // stop if Node is not a BNO
         throwExceptionIfNotBNO(ourIdentity, serviceHub)
 
-        progressTracker.currentStep = RequestingMembership
-        val stx = subFlow(RequestMembershipFlow(ourIdentity, metaData))
+        val configuration = serviceHub.cordaService(BNOConfigurationService::class.java)
+        val notary = configuration.notaryParty()
 
-        val outState = stx.tx.outputs.single()
-        val membershipState = outState.data as MembershipState<*>
+        //txBuilderNoNotary is used to build a transaction with notary
+        val txBuilder = TransactionBuilder(notary)
+        val stx = serviceHub.signInitialTransaction(txBuilder)
 
-        // If auto activate is set then don't need to call ActivateMembership
-        return if (!membershipState.isActive()) {
-            logger.info("Membership is not yet active")
+        if (!bnoMembership.state.data.isActive()) {
+            logger.info("Membership is being activated")
             progressTracker.currentStep = ActivatingMembership
-            val output = stx.tx.outRefsOfType(MembershipState::class.java).single()
+            txBuilder.addInputState(bnoMembership)
 
-            subFlow(ActivateMembershipFlow(output))
+            //transaction will only modify the status of the BNO node and set it to ACTIVE
+            txBuilder.addOutputState(bnoMembership.state.data.copy(
+                            status = MembershipStatus.ACTIVE,
+                            modified = serviceHub.clock.instant()),
+                            MembershipContract.CONTRACT_NAME)
+            txBuilder.addCommand(MembershipContract.Commands.Activate(), ourIdentity.owningKey)
+
+            // sign the transaction so it can be written to the ledger
+            subFlow(FinalityFlow(stx, listOf())) //listOf remains empty since only BNO needed to sign the transaction
+            logger.info("Membership has been activated")
+            progressTracker.currentStep = ActivatedMembership
+            return stx
+
         } else {
-            logger.info("Membership was automatically activated")
-            stx
+            progressTracker.currentStep = AlreadyActvie
+            return stx
         }
     }
 }
 
+/**
+ * This is a convenience flow that can be easily used from a command line
+ *
+ * @param party whose membership state to be activated
+ */
+@InitiatingFlow
+@StartableByRPC
+open class ActivateBnoMembershipFlow(val party: Party) : BusinessNetworkOperatorFlowLogic<SignedTransaction>() {
+
+    companion object {
+        object LOOKING_FOR_MEMBERSHIP_STATE : ProgressTracker.Step("Looking for party's membership state")
+        object ACTIVATING_THE_MEMBERSHIP_STATE : ProgressTracker.Step("Activating the membership state")
+
+        fun tracker() = ProgressTracker(
+                LOOKING_FOR_MEMBERSHIP_STATE,
+                ACTIVATING_THE_MEMBERSHIP_STATE
+        )
+    }
+
+    override val progressTracker = tracker()
+
+    @Suspendable
+    override fun call(): SignedTransaction {
+        progressTracker.currentStep = LOOKING_FOR_MEMBERSHIP_STATE
+        val stateToActivate = findMembershipStateForParty(party)
+
+        progressTracker.currentStep = ACTIVATING_THE_MEMBERSHIP_STATE
+        return subFlow(SelfIssueMembershipFlow(stateToActivate))
+    }
+
+}

--- a/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/SelfIssueMembershipFlow.kt
+++ b/bn-apps/memberships-management/membership-service/src/main/kotlin/com/r3/businessnetworks/membership/flows/bno/SelfIssueMembershipFlow.kt
@@ -26,14 +26,12 @@ import net.corda.core.utilities.ProgressTracker
 @InitiatingFlow(version = 2)
 open class SelfIssueMembershipFlow(val bnoMembership: StateAndRef<MembershipState<Any>>) : FlowLogic<SignedTransaction>() {
     companion object {
-        object ActivatedMembership : ProgressTracker.Step("Membership Activated")
-        object ActivatingMembership : ProgressTracker.Step("Activating Membership")
-        object AlreadyActvie : ProgressTracker.Step("Membership is already active")
-
+        object ACTIVAED_MEMBERSHIP: ProgressTracker.Step("Membership Activated")
+        object ACTIVATING_MEMBERSHIP : ProgressTracker.Step("Activating Membership")
+        
         fun tracker() = ProgressTracker(
-                ActivatedMembership,
-                ActivatingMembership,
-                AlreadyActvie
+                ACTIVATED_MEMEBERSHIP,
+                ACTIVATING_MEMBERSHIP
         )
     }
 
@@ -49,7 +47,7 @@ open class SelfIssueMembershipFlow(val bnoMembership: StateAndRef<MembershipStat
         val configuration = serviceHub.cordaService(BNOConfigurationService::class.java)
         val notary = configuration.notaryParty()
         logger.info("Membership is being activated")
-        progressTracker.currentStep = ActivatingMembership
+        progressTracker.currentStep = ACTIVATING_MEMBERSHIP
 
 
             val txBuilder = TransactionBuilder(notary)
@@ -66,7 +64,7 @@ open class SelfIssueMembershipFlow(val bnoMembership: StateAndRef<MembershipStat
             // sign the transaction so it can be written to the ledger
             subFlow(FinalityFlow(stx, listOf())) //listOf remains empty since only BNO needed to sign the transaction
             logger.info("Membership has been activated")
-            progressTracker.currentStep = ActivatedMembership
+            progressTracker.currentStep = ACTIVATED_MEMBERSHIP
             return subFlow(FinalityFlow(stx, listOf()))
 
     }

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/AbstractFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/AbstractFlowTest.kt
@@ -99,12 +99,15 @@ abstract class AbstractFlowTest(private val numberOfBusinessNetworks : Int,
         mockNetwork.runNetwork()
         return future.getOrThrow()
     }
-
-    fun runSelfIssueMembershipFlow(bnoNode : StartedMockNode, membershipMetadata : Any = SimpleMembershipMetadata(role = "DEFAULT")) : SignedTransaction {
-        val future = bnoNode.startFlow(SelfIssueMembershipFlow(membershipMetadata))
+//, participantNode : StartedMockNode
+    fun runSelfIssueMembershipFlow(bnoNode : StartedMockNode) : SignedTransaction {
+        val membership = getMembership(bnoNode, bnoNode.identity(), bnoNode.identity())
+        val future = bnoNode.startFlow(SelfIssueMembershipFlow(membership))
         mockNetwork.runNetwork()
         return future.getOrThrow()
     }
+
+
 
     fun runRequestMembershipFlow(bnoNode : StartedMockNode, participantNodes : List<StartedMockNode>, membershipMetadata : Any = SimpleMembershipMetadata(role = "DEFAULT")) : List<SignedTransaction> {
         return participantNodes.map { runRequestMembershipFlow(bnoNode, it, membershipMetadata) }

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/SelfIssueMembershipFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/SelfIssueMembershipFlowTest.kt
@@ -1,115 +1,54 @@
-package com.r3.businessnetworks.membership.flows.bno
+package com.r3.businessnetworks.membership.flows
 
-import co.paralleluniverse.fibers.Suspendable
-import com.r3.businessnetworks.membership.flows.NotBNOException
-import com.r3.businessnetworks.membership.flows.bno.service.BNOConfigurationService
-import com.r3.businessnetworks.membership.flows.bno.support.BusinessNetworkOperatorFlowLogic
-import com.r3.businessnetworks.membership.flows.member.OnBoardingRequest
-import com.r3.businessnetworks.membership.flows.member.RequestMembershipFlow
-import com.r3.businessnetworks.membership.flows.member.Utils.throwExceptionIfNotBNO
-import com.r3.businessnetworks.membership.flows.member.service.MemberConfigurationService
+import com.r3.businessnetworks.membership.flows.bno.SelfIssueMembershipFlow
 import com.r3.businessnetworks.membership.states.MembershipContract
-import com.r3.businessnetworks.membership.states.MembershipState
-import com.r3.businessnetworks.membership.states.MembershipStatus
-import net.corda.core.contracts.StateAndRef
-import net.corda.core.flows.FinalityFlow
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.InitiatingFlow
-import net.corda.core.flows.StartableByRPC
-import net.corda.core.identity.Party
-import net.corda.core.transactions.SignedTransaction
-import net.corda.core.transactions.TransactionBuilder
-import net.corda.core.utilities.ProgressTracker
+import net.corda.core.utilities.getOrThrow
+import org.junit.Test
+import kotlin.test.fail
 
-/**
- * Self Issue a Membership.  This can only be done by a BNO,
- * @param bnoMembership bno membership state to be activated
- */
-@Suppress("UNUSED_VARIABLE")
-@StartableByRPC
-@InitiatingFlow(version = 2)
-open class SelfIssueMembershipFlow(val bnoMembership: StateAndRef<MembershipState<Any>>) : FlowLogic<SignedTransaction>() {
-    companion object {
-        object ActivatedMembership : ProgressTracker.Step("Membership Activated")
-        object ActivatingMembership : ProgressTracker.Step("Activating Membership")
-        object AlreadyActvie : ProgressTracker.Step("Membership is already active")
+class SelfIssueMembershipFlow : AbstractFlowTest(
+        numberOfBusinessNetworks = 2,
+        numberOfParticipants = 4,
+        participantRespondingFlows = listOf(NotificationsCounterFlow::class.java)) {
 
-        fun tracker() = ProgressTracker(
-                ActivatedMembership,
-                ActivatingMembership,
-                AlreadyActvie
-        )
+    @Test
+    fun `self issue happy path`() {
+        val bnoNode = bnoNodes.first()
+        //val participantNode = participantsNodes.first()
+
+        runRequestMembershipFlow(bnoNode, bnoNode)
+        // membership state before activation
+        val inputMembership = getMembership(bnoNode, bnoNode.identity(), bnoNode.identity())
+        val stx = runSelfIssueMembershipFlow(bnoNode)
+        ////stx.inputs.
+
+        val outputTxState = stx.tx.outputs.single()
+        val command = stx.tx.commands.single()
+
+        assert(MembershipContract.CONTRACT_NAME == outputTxState.contract)
+        assert(command.value is MembershipContract.Commands.Activate)
+        assert(stx.tx.inputs.single() == inputMembership.ref)
+
+        stx.verifyRequiredSignatures()
     }
 
-    override val progressTracker = tracker()
+    @Test
+    fun `only BNO should be able to start the flow`() {
+        val bnoNode = bnoNodes.first()
+        val participantNode = participantsNodes.first()
 
-    @Suspendable
+        //Populate with data
+        runRequestMembershipFlow(bnoNode, participantNode)
 
-    //The call function will build a transaction which will only
-    // modify the BNO status and then self sign the transaction
-    override fun call(): SignedTransaction {
-        // stop if Node is not a BNO
-        throwExceptionIfNotBNO(ourIdentity, serviceHub)
-        val configuration = serviceHub.cordaService(BNOConfigurationService::class.java)
-        val notary = configuration.notaryParty()
 
-        //txBuilderNoNotary is used to build a transaction with notary
-        val txBuilder = TransactionBuilder(notary)
-        val stx = serviceHub.signInitialTransaction(txBuilder)
-
-        if (!bnoMembership.state.data.isActive()) {
-            logger.info("Membership is being activated")
-            progressTracker.currentStep = ActivatingMembership
-            txBuilder.addInputState(bnoMembership)
-
-            //transaction will only modify the status of the BNO node and set it to ACTIVE
-            txBuilder.addOutputState(bnoMembership.state.data.copy(
-                            status = MembershipStatus.ACTIVE,
-                            modified = serviceHub.clock.instant()),
-                            MembershipContract.CONTRACT_NAME)
-            txBuilder.addCommand(MembershipContract.Commands.Activate(), ourIdentity.owningKey)
-
-            // sign the transaction so it can be written to the ledger
-            subFlow(FinalityFlow(stx, listOf())) //listOf remains empty since only BNO needed to sign the transaction
-            logger.info("Membership has been activated")
-            progressTracker.currentStep = ActivatedMembership
-            return stx
-
-        } else {
-            progressTracker.currentStep = AlreadyActvie
-            return stx
+        val membership = getMembership(participantNode, participantNode.identity(), bnoNode.identity())
+        try {
+            val future = participantNode.startFlow(SelfIssueMembershipFlow(membership))
+            mockNetwork.runNetwork()
+            future.getOrThrow()
+            fail()
+        } catch (e : BNONotWhitelisted) {
         }
-    }
-}
-
-/**
- * This is a convenience flow that can be easily used from a command line
- *
- * @param party whose membership state to be activated
- */
-@InitiatingFlow
-@StartableByRPC
-open class ActivateBnoMembershipFlow(val party: Party) : BusinessNetworkOperatorFlowLogic<SignedTransaction>() {
-
-    companion object {
-        object LOOKING_FOR_MEMBERSHIP_STATE : ProgressTracker.Step("Looking for party's membership state")
-        object ACTIVATING_THE_MEMBERSHIP_STATE : ProgressTracker.Step("Activating the membership state")
-
-        fun tracker() = ProgressTracker(
-                LOOKING_FOR_MEMBERSHIP_STATE,
-                ACTIVATING_THE_MEMBERSHIP_STATE
-        )
-    }
-
-    override val progressTracker = tracker()
-
-    @Suspendable
-    override fun call(): SignedTransaction {
-        progressTracker.currentStep = LOOKING_FOR_MEMBERSHIP_STATE
-        val stateToActivate = findMembershipStateForParty(party)
-
-        progressTracker.currentStep = ACTIVATING_THE_MEMBERSHIP_STATE
-        return subFlow(SelfIssueMembershipFlow(stateToActivate))
     }
 
 }

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/SelfIssueMembershipFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/SelfIssueMembershipFlowTest.kt
@@ -6,7 +6,7 @@ import net.corda.core.utilities.getOrThrow
 import org.junit.Test
 import kotlin.test.fail
 
-class SelfIssueMembershipFlow : AbstractFlowTest(
+class SelfIssueMembershipFlowTest : AbstractFlowTest(
         numberOfBusinessNetworks = 2,
         numberOfParticipants = 4,
         participantRespondingFlows = listOf(NotificationsCounterFlow::class.java)) {

--- a/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/SelfIssueMembershipFlowTest.kt
+++ b/bn-apps/memberships-management/membership-service/src/test/kotlin/com/r3/businessnetworks/membership/flows/SelfIssueMembershipFlowTest.kt
@@ -1,51 +1,115 @@
-package com.r3.businessnetworks.membership.flows
+package com.r3.businessnetworks.membership.flows.bno
 
-import com.r3.businessnetworks.membership.flows.bno.RequestMembershipFlowResponder
-import com.r3.businessnetworks.membership.flows.bno.service.DatabaseService
+import co.paralleluniverse.fibers.Suspendable
+import com.r3.businessnetworks.membership.flows.NotBNOException
+import com.r3.businessnetworks.membership.flows.bno.service.BNOConfigurationService
+import com.r3.businessnetworks.membership.flows.bno.support.BusinessNetworkOperatorFlowLogic
+import com.r3.businessnetworks.membership.flows.member.OnBoardingRequest
+import com.r3.businessnetworks.membership.flows.member.RequestMembershipFlow
+import com.r3.businessnetworks.membership.flows.member.Utils.throwExceptionIfNotBNO
 import com.r3.businessnetworks.membership.flows.member.service.MemberConfigurationService
 import com.r3.businessnetworks.membership.states.MembershipContract
 import com.r3.businessnetworks.membership.states.MembershipState
-import com.r3.businessnetworks.membership.testextensions.RequestMembershipFlowResponderWithMetadataVerification
-import net.corda.core.flows.FlowException
-import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
-import kotlin.test.fail
+import com.r3.businessnetworks.membership.states.MembershipStatus
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.flows.FinalityFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.ProgressTracker
 
-class SelfIssueMembershipFlowTest : AbstractFlowTest(numberOfBusinessNetworks = 2,
-        numberOfParticipants = 2,
-        participantRespondingFlows = listOf(RequestMembershipFlowResponder::class.java)) {
+/**
+ * Self Issue a Membership.  This can only be done by a BNO,
+ * @param bnoMembership bno membership state to be activated
+ */
+@Suppress("UNUSED_VARIABLE")
+@StartableByRPC
+@InitiatingFlow(version = 2)
+open class SelfIssueMembershipFlow(val bnoMembership: StateAndRef<MembershipState<Any>>) : FlowLogic<SignedTransaction>() {
+    companion object {
+        object ActivatedMembership : ProgressTracker.Step("Membership Activated")
+        object ActivatingMembership : ProgressTracker.Step("Activating Membership")
+        object AlreadyActvie : ProgressTracker.Step("Membership is already active")
 
-    @Test
-    fun `self issue happy path`() {
-        val bnoNode = bnoNodes.first()
-
-        val stx = runSelfIssueMembershipFlow(bnoNode)
-        
-        assert(stx.notary!!.name == notaryName)
-
-        val outputWithContract = stx.tx.outputs.single()
-        val outputMembership = outputWithContract.data as MembershipState<*>
-        val command = stx.tx.commands.single()
-
-        assert(command.value is MembershipContract.Commands.Activate)
-        assert(outputWithContract.contract == MembershipContract.CONTRACT_NAME)
-        assert(outputMembership.bno == bnoNode.identity())
-        assert(outputMembership.member == bnoNode.identity())
-        stx.verifyRequiredSignatures()
+        fun tracker() = ProgressTracker(
+                ActivatedMembership,
+                ActivatingMembership,
+                AlreadyActvie
+        )
     }
 
-    @Test
-    fun `self issue should fail if a membership state already exists`() {
-        val bnoNode = bnoNodes.first()
+    override val progressTracker = tracker()
 
-        runSelfIssueMembershipFlow(bnoNode)
+    @Suspendable
 
-        try {
-            runSelfIssueMembershipFlow(bnoNode)
-            fail()
-        } catch (e : FlowException) {
-            assert("Membership already exists" == e.message)
+    //The call function will build a transaction which will only
+    // modify the BNO status and then self sign the transaction
+    override fun call(): SignedTransaction {
+        // stop if Node is not a BNO
+        throwExceptionIfNotBNO(ourIdentity, serviceHub)
+        val configuration = serviceHub.cordaService(BNOConfigurationService::class.java)
+        val notary = configuration.notaryParty()
+
+        //txBuilderNoNotary is used to build a transaction with notary
+        val txBuilder = TransactionBuilder(notary)
+        val stx = serviceHub.signInitialTransaction(txBuilder)
+
+        if (!bnoMembership.state.data.isActive()) {
+            logger.info("Membership is being activated")
+            progressTracker.currentStep = ActivatingMembership
+            txBuilder.addInputState(bnoMembership)
+
+            //transaction will only modify the status of the BNO node and set it to ACTIVE
+            txBuilder.addOutputState(bnoMembership.state.data.copy(
+                            status = MembershipStatus.ACTIVE,
+                            modified = serviceHub.clock.instant()),
+                            MembershipContract.CONTRACT_NAME)
+            txBuilder.addCommand(MembershipContract.Commands.Activate(), ourIdentity.owningKey)
+
+            // sign the transaction so it can be written to the ledger
+            subFlow(FinalityFlow(stx, listOf())) //listOf remains empty since only BNO needed to sign the transaction
+            logger.info("Membership has been activated")
+            progressTracker.currentStep = ActivatedMembership
+            return stx
+
+        } else {
+            progressTracker.currentStep = AlreadyActvie
+            return stx
         }
     }
+}
+
+/**
+ * This is a convenience flow that can be easily used from a command line
+ *
+ * @param party whose membership state to be activated
+ */
+@InitiatingFlow
+@StartableByRPC
+open class ActivateBnoMembershipFlow(val party: Party) : BusinessNetworkOperatorFlowLogic<SignedTransaction>() {
+
+    companion object {
+        object LOOKING_FOR_MEMBERSHIP_STATE : ProgressTracker.Step("Looking for party's membership state")
+        object ACTIVATING_THE_MEMBERSHIP_STATE : ProgressTracker.Step("Activating the membership state")
+
+        fun tracker() = ProgressTracker(
+                LOOKING_FOR_MEMBERSHIP_STATE,
+                ACTIVATING_THE_MEMBERSHIP_STATE
+        )
+    }
+
+    override val progressTracker = tracker()
+
+    @Suspendable
+    override fun call(): SignedTransaction {
+        progressTracker.currentStep = LOOKING_FOR_MEMBERSHIP_STATE
+        val stateToActivate = findMembershipStateForParty(party)
+
+        progressTracker.currentStep = ACTIVATING_THE_MEMBERSHIP_STATE
+        return subFlow(SelfIssueMembershipFlow(stateToActivate))
+    }
+
 }


### PR DESCRIPTION

1) Updates the status (passed)
2) Check only BNO can call the flow(passed)